### PR TITLE
feat(core): four-bucket EntityStateEntry (user_data, local_data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **arcane-core**: `EntityStateEntry` now carries **`user_data`** and **`local_data`** (JSON) aligned with the [four-bucket state model](docs/architecture/four-bucket-state-model.md): replicated simulation payload vs cluster-local fields; `local_data` is never serialized on `EntityStateDelta`. Added `EntityStateEntry::new`.
 - **arcane-infra**: WebSocket `PLAYER_STATE` accepts optional **`user_data`**; **`local_data`** is never read from clients.
+- **arcane-core**: `local_data` uses **`skip_deserializing`** so replication/Redis JSON cannot inject bucket-3 state (regression test added).
 
 ## [0.1.0] - (initial split)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **arcane-core**: `EntityStateEntry` now carries **`user_data`** and **`local_data`** (JSON) aligned with the [four-bucket state model](docs/architecture/four-bucket-state-model.md): replicated simulation payload vs cluster-local fields; `local_data` is never serialized on `EntityStateDelta`. Added `EntityStateEntry::new`.
+- **arcane-infra**: WebSocket `PLAYER_STATE` accepts optional **`user_data`**; **`local_data`** is never read from clients.
+
 ## [0.1.0] - (initial split)
 
 - **arcane-core**: Traits and shared types (IClusteringModel, IServerPool, IReplicationChannel, IWorldSimulator; Vec2, Vec3, ClusterGeometry, WorldStateView, etc.).

--- a/crates/arcane-core/Cargo.toml
+++ b/crates/arcane-core/Cargo.toml
@@ -6,7 +6,5 @@ description = "Arcane Engine — core traits and shared types (IF-01–04)"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-uuid = { version = "1.0", features = ["v4", "serde"] }
-
-[dev-dependencies]
 serde_json = "1.0"
+uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -6,7 +6,7 @@
 //! - `types`: shared math and geometry primitives (`Vec2`, `Vec3`, `ClusterGeometry`).
 //! - `clustering_model`: merge/split decision interface consumed by manager logic.
 //! - `server_pool`: allocation/release contract for cluster server capacity.
-//! - `replication_channel`: neighbor-delta contract and message schema.
+//! - `replication_channel`: neighbor-delta contract, [`EntityStateEntry`](replication_channel::EntityStateEntry) (four-bucket spine + JSON fields), [`IReplicationChannel`](replication_channel::IReplicationChannel).
 //! - `world_simulator`: contract for unobserved entity state progression.
 //!
 //! ## Interaction model

--- a/crates/arcane-core/src/replication_channel.rs
+++ b/crates/arcane-core/src/replication_channel.rs
@@ -3,6 +3,12 @@
 //! Defines the delta payload shape shared between cluster runtime and transport adapters.
 //! Infra components (`ReplicationChannelManager`, Redis adapter, neighbor subscribers) exchange
 //! `EntityStateDelta` values defined here.
+//!
+//! # Four-bucket model
+//!
+//! [`EntityStateEntry`] maps to the **v1 four-bucket** entity state model (spine, replicated
+//! simulation JSON, cluster-local JSON, SpacetimeDB durable). See
+//! `docs/architecture/four-bucket-state-model.md` in the repository.
 
 use crate::types::Vec3;
 use uuid::Uuid;
@@ -27,6 +33,18 @@ pub struct EntityStateDelta {
     pub removed: Vec<Uuid>,
 }
 
+/// One entity on the cluster following the **four-bucket** model (see repo doc
+/// `docs/architecture/four-bucket-state-model.md`).
+///
+/// | Bucket | Fields |
+/// |--------|--------|
+/// | **1 — Spine** (routing + pose) | `entity_id`, `cluster_id`, `position`, `velocity` |
+/// | **2 — Replicated simulation** | [`Self::user_data`] (JSON); on Redis / reference WebSocket when not null |
+/// | **3 — Cluster-local** | [`Self::local_data`] — **never** serialized into [`EntityStateDelta`]; not trusted from clients |
+/// | **4 — Durable** | SpacetimeDB tables / reducers — not stored on this struct |
+///
+/// **Wire:** `entity_id`, `cluster_id`, `position`, `velocity`, and `user_data` (omitted when null).
+/// `local_data` uses [`serde::Serialize`] with skip — it does not cross the replication mesh.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct EntityStateEntry {
     pub entity_id: Uuid,
@@ -34,6 +52,25 @@ pub struct EntityStateEntry {
     pub cluster_id: Uuid,
     pub position: Vec3,
     pub velocity: Vec3,
+    /// **Bucket 2** — replicated game JSON (neighbors, clients). Default `null`; omitted when null.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub user_data: serde_json::Value,
+    /// **Bucket 3** — cluster process only; never sent on [`EntityStateDelta`]. Do not trust from clients.
+    #[serde(default, skip_serializing)]
+    pub local_data: serde_json::Value,
+}
+
+impl EntityStateEntry {
+    pub fn new(entity_id: Uuid, cluster_id: Uuid, position: Vec3, velocity: Vec3) -> Self {
+        Self {
+            entity_id,
+            cluster_id,
+            position,
+            velocity,
+            user_data: serde_json::Value::Null,
+            local_data: serde_json::Value::Null,
+        }
+    }
 }
 
 /// Reason for closing a channel.
@@ -66,12 +103,12 @@ mod tests {
             seq: 7,
             tick: 100,
             timestamp: 1.5,
-            updated: vec![EntityStateEntry {
-                entity_id: eid,
-                cluster_id: cid,
-                position: Vec3::new(1.0, 2.0, 3.0),
-                velocity: Vec3::new(0.1, 0.0, -0.2),
-            }],
+            updated: vec![EntityStateEntry::new(
+                eid,
+                cid,
+                Vec3::new(1.0, 2.0, 3.0),
+                Vec3::new(0.1, 0.0, -0.2),
+            )],
             removed: vec![Uuid::from_u128(1)],
         };
         let json = serde_json::to_string(&delta).unwrap();
@@ -82,5 +119,57 @@ mod tests {
         assert_eq!(delta.updated[0].entity_id, back.updated[0].entity_id);
         assert_eq!(delta.updated[0].position, back.updated[0].position);
         assert_eq!(delta.removed, back.removed);
+    }
+
+    #[test]
+    fn entity_state_entry_user_data_roundtrip() {
+        let cid = Uuid::nil();
+        let eid = Uuid::from_u128(42);
+        let mut e = EntityStateEntry::new(
+            eid,
+            cid,
+            Vec3::new(1.0, 0.0, 2.0),
+            Vec3::new(0.0, 0.0, 0.0),
+        );
+        e.user_data = serde_json::json!({"kind": "projectile", "owner": "a"});
+        let json = serde_json::to_string(&e).unwrap();
+        let back: EntityStateEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.user_data, e.user_data);
+    }
+
+    #[test]
+    fn entity_state_entry_local_data_not_on_replication_wire() {
+        let cid = Uuid::nil();
+        let eid = Uuid::from_u128(7);
+        let mut e = EntityStateEntry::new(
+            eid,
+            cid,
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
+        );
+        e.user_data = serde_json::json!({"visible": true});
+        e.local_data = serde_json::json!({"cooldown_s": 2.5});
+
+        let delta = EntityStateDelta {
+            source_cluster_id: cid,
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: vec![e],
+            removed: vec![],
+        };
+        let json = serde_json::to_string(&delta).unwrap();
+        assert!(
+            !json.contains("cooldown"),
+            "local_data must not appear in replication JSON: {}",
+            json
+        );
+
+        let back: EntityStateDelta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.updated[0].user_data, serde_json::json!({"visible": true}));
+        assert!(
+            back.updated[0].local_data.is_null(),
+            "after wire roundtrip local_data is absent (default null)"
+        );
     }
 }

--- a/crates/arcane-core/src/replication_channel.rs
+++ b/crates/arcane-core/src/replication_channel.rs
@@ -55,8 +55,11 @@ pub struct EntityStateEntry {
     /// **Bucket 2** — replicated game JSON (neighbors, clients). Default `null`; omitted when null.
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub user_data: serde_json::Value,
-    /// **Bucket 3** — cluster process only; never sent on [`EntityStateDelta`]. Do not trust from clients.
-    #[serde(default, skip_serializing)]
+    /// **Bucket 3** — cluster process only; never sent on [`EntityStateDelta`].
+    ///
+    /// **`skip_deserializing`:** replication JSON must never hydrate this field from the wire (neighbors,
+    /// Redis, or crafted payloads). Only this process may set `local_data` in memory after deserialize.
+    #[serde(default, skip_serializing, skip_deserializing)]
     pub local_data: serde_json::Value,
 }
 
@@ -165,6 +168,30 @@ mod tests {
         assert!(
             back.updated[0].local_data.is_null(),
             "after wire roundtrip local_data is absent (default null)"
+        );
+    }
+
+    #[test]
+    fn entity_state_entry_local_data_not_accepted_from_replication_json() {
+        // Malicious or buggy neighbor must not inject bucket-3 state via the wire.
+        let json = r#"{
+            "source_cluster_id":"00000000-0000-0000-0000-000000000001",
+            "seq":1,"tick":1,"timestamp":0.0,
+            "updated":[{
+                "entity_id":"00000000-0000-0000-0000-000000000002",
+                "cluster_id":"00000000-0000-0000-0000-000000000001",
+                "position":{"x":1.0,"y":0.0,"z":0.0},
+                "velocity":{"x":0.0,"y":0.0,"z":0.0},
+                "user_data":{"ok":true},
+                "local_data":{"injected":true}
+            }],
+            "removed":[]
+        }"#;
+        let delta: EntityStateDelta = serde_json::from_str(json).unwrap();
+        assert_eq!(delta.updated[0].user_data, serde_json::json!({"ok": true}));
+        assert!(
+            delta.updated[0].local_data.is_null(),
+            "local_data from JSON must be ignored (skip_deserializing)"
         );
     }
 }

--- a/crates/arcane-core/src/replication_channel.rs
+++ b/crates/arcane-core/src/replication_channel.rs
@@ -125,12 +125,8 @@ mod tests {
     fn entity_state_entry_user_data_roundtrip() {
         let cid = Uuid::nil();
         let eid = Uuid::from_u128(42);
-        let mut e = EntityStateEntry::new(
-            eid,
-            cid,
-            Vec3::new(1.0, 0.0, 2.0),
-            Vec3::new(0.0, 0.0, 0.0),
-        );
+        let mut e =
+            EntityStateEntry::new(eid, cid, Vec3::new(1.0, 0.0, 2.0), Vec3::new(0.0, 0.0, 0.0));
         e.user_data = serde_json::json!({"kind": "projectile", "owner": "a"});
         let json = serde_json::to_string(&e).unwrap();
         let back: EntityStateEntry = serde_json::from_str(&json).unwrap();
@@ -141,12 +137,8 @@ mod tests {
     fn entity_state_entry_local_data_not_on_replication_wire() {
         let cid = Uuid::nil();
         let eid = Uuid::from_u128(7);
-        let mut e = EntityStateEntry::new(
-            eid,
-            cid,
-            Vec3::new(0.0, 0.0, 0.0),
-            Vec3::new(0.0, 0.0, 0.0),
-        );
+        let mut e =
+            EntityStateEntry::new(eid, cid, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
         e.user_data = serde_json::json!({"visible": true});
         e.local_data = serde_json::json!({"cooldown_s": 2.5});
 
@@ -166,7 +158,10 @@ mod tests {
         );
 
         let back: EntityStateDelta = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.updated[0].user_data, serde_json::json!({"visible": true}));
+        assert_eq!(
+            back.updated[0].user_data,
+            serde_json::json!({"visible": true})
+        );
         assert!(
             back.updated[0].local_data.is_null(),
             "after wire roundtrip local_data is absent (default null)"

--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -144,12 +144,12 @@ mod tests {
     use uuid::Uuid;
 
     fn mk_entry(entity_id: Uuid, cluster_id: Uuid, x: f64) -> EntityStateEntry {
-        EntityStateEntry {
+        EntityStateEntry::new(
             entity_id,
             cluster_id,
-            position: Vec3::new(x, 0.0, 0.0),
-            velocity: Vec3::new(0.0, 0.0, 0.0),
-        }
+            Vec3::new(x, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
+        )
     }
 
     #[test]

--- a/crates/arcane-infra/src/neighbor_subscriber.rs
+++ b/crates/arcane-infra/src/neighbor_subscriber.rs
@@ -81,12 +81,12 @@ mod tests {
             seq: 5,
             tick: 42,
             timestamp: 1.23,
-            updated: vec![EntityStateEntry {
-                entity_id: Uuid::from_u128(2),
-                cluster_id: Uuid::from_u128(3),
-                position: Vec3::new(1.0, 2.0, 3.0),
-                velocity: Vec3::new(0.1, 0.2, 0.3),
-            }],
+            updated: vec![EntityStateEntry::new(
+                Uuid::from_u128(2),
+                Uuid::from_u128(3),
+                Vec3::new(1.0, 2.0, 3.0),
+                Vec3::new(0.1, 0.2, 0.3),
+            )],
             removed: vec![Uuid::from_u128(4)],
         };
         let payload = serde_json::to_string(&delta).unwrap();

--- a/crates/arcane-infra/src/spacetimedb_persist.rs
+++ b/crates/arcane-infra/src/spacetimedb_persist.rs
@@ -5,6 +5,9 @@
 //! - encode `EntityStateEntry` batches into SpacetimeDB reducer payload shape
 //! - send chunked HTTP requests and log success/failure totals
 //!
+//! **Four buckets:** this path mirrors **bucket 1** (pose) into **bucket 4** (durable tables) at a
+//! throttled cadence — not a substitute for hot Redis replication between clusters.
+//!
 //! This module does not own simulation timing; `cluster_runner` decides when to call it.
 
 use std::time::{Duration, Instant};
@@ -164,12 +167,12 @@ mod tests {
     use uuid::Uuid;
 
     fn mk_entry(id: Uuid, x: f64, y: f64, z: f64) -> EntityStateEntry {
-        EntityStateEntry {
-            entity_id: id,
-            cluster_id: Uuid::nil(),
-            position: Vec3::new(x, y, z),
-            velocity: Vec3::new(9.0, 9.0, 9.0),
-        }
+        EntityStateEntry::new(
+            id,
+            Uuid::nil(),
+            Vec3::new(x, y, z),
+            Vec3::new(9.0, 9.0, 9.0),
+        )
     }
 
     #[test]

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -1,5 +1,10 @@
 //! WebSocket server for cluster state broadcast. Built only with feature "cluster-ws".
 //! Accepts incoming PLAYER_STATE messages from clients and forwards them to the tick loop.
+//!
+//! **Buckets:** inbound JSON may set **spine** (`position`, `velocity`) and **bucket 2**
+//! ([`EntityStateEntry::user_data`](arcane_core::replication_channel::EntityStateEntry::user_data)).
+//! **Bucket 3** ([`local_data`](arcane_core::replication_channel::EntityStateEntry::local_data)) is
+//! never taken from the client; it stays default until the cluster sets it server-side.
 
 use std::net::SocketAddr;
 use std::sync::mpsc::{Receiver, Sender};
@@ -11,7 +16,9 @@ use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
 
-/// Incoming message from a client. Expects JSON: {"type":"PLAYER_STATE","entity_id":"uuid","position":{"x",y,z},"velocity":{"x",y,z}}
+/// Incoming message from a client. Expects JSON:
+/// `{"type":"PLAYER_STATE","entity_id":"uuid","position":{...},"velocity":{...},"user_data":?}`.
+/// Optional **`user_data`** is **bucket 2** (replicated simulation JSON). Unknown keys are ignored.
 #[derive(serde::Deserialize)]
 struct PlayerStateMessage {
     #[serde(rename = "type")]
@@ -19,6 +26,8 @@ struct PlayerStateMessage {
     entity_id: String,
     position: Vec3Message,
     velocity: Vec3Message,
+    #[serde(default)]
+    user_data: serde_json::Value,
 }
 
 #[derive(serde::Deserialize)]
@@ -35,12 +44,14 @@ fn parse_player_state(text: &str) -> Option<EntityStateEntry> {
     }
     let entity_id = Uuid::parse_str(&msg.entity_id).ok()?;
     // cluster_id set by cluster binary when applying (this connection is to that cluster)
-    Some(EntityStateEntry {
+    let mut entry = EntityStateEntry::new(
         entity_id,
-        cluster_id: Uuid::nil(),
-        position: Vec3::new(msg.position.x, msg.position.y, msg.position.z),
-        velocity: Vec3::new(msg.velocity.x, msg.velocity.y, msg.velocity.z),
-    })
+        Uuid::nil(),
+        Vec3::new(msg.position.x, msg.position.y, msg.position.z),
+        Vec3::new(msg.velocity.x, msg.velocity.y, msg.velocity.z),
+    );
+    entry.user_data = msg.user_data;
+    Some(entry)
 }
 
 fn should_keep_ws_loop_running_on_broadcast_error(
@@ -162,6 +173,18 @@ mod tests {
     fn parse_player_state_rejects_non_player_state_messages() {
         let payload = r#"{"type":"PING","entity_id":"00000000-0000-0000-0000-000000000000","position":{"x":0.0,"y":0.0,"z":0.0},"velocity":{"x":0.0,"y":0.0,"z":0.0}}"#;
         assert!(parse_player_state(payload).is_none());
+    }
+
+    #[test]
+    fn parse_player_state_accepts_optional_user_data() {
+        let id = Uuid::from_u128(2);
+        let payload = format!(
+            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":0.0,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}},"user_data":{{"stamina":99}}}}"#,
+            id
+        );
+        let parsed = parse_player_state(&payload).expect("parse");
+        assert_eq!(parsed.user_data, serde_json::json!({"stamina": 99}));
+        assert!(parsed.local_data.is_null());
     }
 
     #[test]

--- a/crates/arcane-infra/tests/cluster_server_tests.rs
+++ b/crates/arcane-infra/tests/cluster_server_tests.rs
@@ -66,12 +66,12 @@ fn tick_returns_delta_with_entities() {
     let cluster_id = Uuid::new_v4();
     let server = ClusterServer::new(cluster_id);
     let entity_id = Uuid::new_v4();
-    server.add_entity(EntityStateEntry {
+    server.add_entity(EntityStateEntry::new(
         entity_id,
         cluster_id,
-        position: Vec3::new(1.0, 2.0, 3.0),
-        velocity: Vec3::new(0.0, 0.0, 0.0),
-    });
+        Vec3::new(1.0, 2.0, 3.0),
+        Vec3::new(0.0, 0.0, 0.0),
+    ));
     let delta = server.tick();
     assert_eq!(delta.source_cluster_id, cluster_id);
     assert_eq!(delta.tick, 1);
@@ -91,12 +91,12 @@ fn remove_entity_appears_in_next_delta_removed() {
     let cluster_id = Uuid::new_v4();
     let server = ClusterServer::new(cluster_id);
     let entity_id = Uuid::new_v4();
-    server.add_entity(EntityStateEntry {
+    server.add_entity(EntityStateEntry::new(
         entity_id,
         cluster_id,
-        position: Vec3::new(0.0, 0.0, 0.0),
-        velocity: Vec3::new(0.0, 0.0, 0.0),
-    });
+        Vec3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 0.0),
+    ));
     let _ = server.tick();
     server.remove_entity(entity_id);
     let delta = server.tick();

--- a/crates/arcane-infra/tests/integration_tests.rs
+++ b/crates/arcane-infra/tests/integration_tests.rs
@@ -149,12 +149,12 @@ fn redis_channel_publish_received_by_subscriber() {
         seq: 1,
         tick: 10,
         timestamp: 100.0,
-        updated: vec![EntityStateEntry {
-            entity_id: Uuid::from_bytes([5u8; 16]),
-            cluster_id: source_id,
-            position: Vec3::new(1.0, 2.0, 3.0),
-            velocity: Vec3::new(0.0, 0.0, 0.0),
-        }],
+        updated: vec![EntityStateEntry::new(
+            Uuid::from_bytes([5u8; 16]),
+            source_id,
+            Vec3::new(1.0, 2.0, 3.0),
+            Vec3::new(0.0, 0.0, 0.0),
+        )],
         removed: vec![],
     };
     let channel = RedisReplicationChannel::new(source_id, conn_pub);

--- a/crates/arcane-infra/tests/replication_channel_manager_tests.rs
+++ b/crates/arcane-infra/tests/replication_channel_manager_tests.rs
@@ -39,12 +39,12 @@ fn send_to_neighbors_no_panic_before_start() {
         seq: 0,
         tick: 0,
         timestamp: 0.0,
-        updated: vec![EntityStateEntry {
-            entity_id: Uuid::new_v4(),
-            cluster_id: mgr.cluster_id(),
-            position: Vec3::new(0.0, 0.0, 0.0),
-            velocity: Vec3::new(0.0, 0.0, 0.0),
-        }],
+        updated: vec![EntityStateEntry::new(
+            Uuid::new_v4(),
+            mgr.cluster_id(),
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
+        )],
         removed: vec![],
     };
     mgr.send_to_neighbors(delta);

--- a/docs/architecture/four-bucket-state-model.md
+++ b/docs/architecture/four-bucket-state-model.md
@@ -16,7 +16,7 @@ Multiplayer backends mix **hot replication** (cluster mesh, clients), **process-
 |---|------|------------|----------------------|------------------|
 | **1** | **Spine (routing + pose)** | Fixed fields the platform understands for routing, replication, and interest management. | Hot path; in-memory; replicated every tick as part of the entity row. | `entity_id`, `cluster_id`, `position`, `velocity` |
 | **2** | **Replicated simulation payload** | Game-defined data that **must** cross the cluster mesh and usually reach clients, updated with simulation. | Hot path; serialized on Redis and (today) WebSocket payloads when present. | `EntityStateEntry::user_data` (JSON) |
-| **3** | **Cluster-local / ephemeral** | State that **must not** leave this cluster process on the replication wire. | Memory only; **lost** on process crash or if an entry is replaced from a neighbor delta without rehydrating. | `EntityStateEntry::local_data` (JSON); any fields on your [`ClusterSimulation`](../../crates/arcane-core/src/cluster_simulation.rs) implementation |
+| **3** | **Cluster-local / ephemeral** | State that **must not** leave this cluster process on the replication wire. | Memory only; **lost** on process crash or if an entry is replaced from a neighbor delta without rehydrating. | `EntityStateEntry::local_data` (JSON); plus any extra process-only state your simulation holds (see [physics-backends-and-unreal.md](physics-backends-and-unreal.md) for optional per-tick hooks) |
 | **4** | **Durable authoritative** | Transactional, persistent outcomes and tables clients may subscribe to via SpacetimeDB. | Not on the Redis tick hot path; written via reducers / module APIs on a throttled or event-driven cadence. | SpacetimeDB tables, reducers, subscriptions |
 
 ---
@@ -34,13 +34,12 @@ Source of truth: [`crates/arcane-core/src/replication_channel.rs`](../../crates/
 | `user_data` | **2 — Replicated simulation** | Omitted from JSON when `null`. On the wire to neighbors and (current reference server) clients. |
 | `local_data` | **3 — Cluster-local** | **`#[serde(skip_serializing)]`** — never part of `EntityStateDelta` JSON. Not trusted from clients; set server-side. Incoming neighbor rows arrive with `local_data` defaulted / empty for that entity. |
 
-### 3.2 Cluster simulation hook
+### 3.2 Per-tick simulation (optional)
 
-[`ClusterSimulation::on_tick`](../../crates/arcane-core/src/cluster_simulation.rs) receives `ClusterTickContext` with mutable `entities: &mut HashMap<Uuid, EntityStateEntry>`.
+Authoritative simulation may update **buckets 1–3** in memory each tick (pose, `user_data`, `local_data`). A future or game-specific **per-tick hook** in the cluster runtime is described in [physics-backends-and-unreal.md](physics-backends-and-unreal.md) (not required for using the four-bucket **data** model on the wire).
 
-- May read/write **bucket 1** and **2** (pose and `user_data`) for authoritative simulation.
-- May read/write **bucket 3** (`local_data` and internal structs on the simulation type).
-- **Bucket 4** is **not** updated inside this hook alone: call SpacetimeDB from your integration layer (reducers, SDK) when discrete events or persist windows require it.
+- Typical rules: read/write **bucket 1** and **2** for integrated motion and replicated game fields; use **bucket 3** for scratch that must not leave the process on Redis.
+- **Bucket 4** is **not** satisfied by mutating `EntityStateEntry` alone: use SpacetimeDB reducers / module APIs when discrete events or durable tables require it.
 
 ### 3.3 SpacetimeDB
 
@@ -81,20 +80,26 @@ Engine-style per-property replication (Unreal-style conditions, dormancy, per-fi
 
 Use this when updating types or wires so they stay consistent with this model.
 
-- [ ] Read this doc and [`EntityStateEntry`](../../crates/arcane-core/src/replication_channel.rs) doc comments; confirm no contradiction (fix code comments or this doc in PR if drift).
-- [ ] [`docs/architecture/README.md`](README.md) indexes this file.
-- [ ] Optional: add a short subsection under [`docs/MODULE_INTERACTIONS.md`](../MODULE_INTERACTIONS.md) pointing here (one paragraph).
-- [ ] If benchmarks or demos embed state, add a one-line comment in their README or module pointing to this doc for “where does this field live?”
+- [x] Read this doc and [`EntityStateEntry`](../../crates/arcane-core/src/replication_channel.rs) doc comments; confirm no contradiction (fix code comments or this doc in PR if drift).
+- [x] [`docs/architecture/README.md`](README.md) indexes this file.
+- [x] Pointer from [`docs/MODULE_INTERACTIONS.md`](../MODULE_INTERACTIONS.md).
+- [ ] If external benchmarks or demos embed state, pin **crate + module versions** and record manifests next to results (see §8).
 
 **Non-goals for this checklist:** unrelated features (per-client visibility, async persist refactor, crash recovery) — track those separately in your own planning.
 
 ---
 
-## 8. Quick reference card
+## 8. Workload and version pinning (benchmarks)
+
+Ceilings and comparisons are only meaningful when **Arcane’s crate version**, any **SpacetimeDB module version**, and **run manifests** (rates, visibility, authority path) are recorded next to published numbers. External harness repositories should store that metadata beside CSVs or dashboards so “what lived in which bucket” can be reconstructed.
+
+---
+
+## 9. Quick reference card
 
 ```
 Spine        → entity_id, cluster_id, position, velocity
 Replicated   → user_data (JSON, on Redis + WS in reference server)
-Local        → local_data + ClusterSimulation-owned memory
+Local        → local_data + other process-only simulation memory
 Durable      → SpacetimeDB tables / reducers / subscriptions
 ```

--- a/docs/architecture/four-bucket-state-model.md
+++ b/docs/architecture/four-bucket-state-model.md
@@ -32,7 +32,7 @@ Source of truth: [`crates/arcane-core/src/replication_channel.rs`](../../crates/
 | `entity_id`, `cluster_id` | **1 — Spine** | Identity and ownership for routing and display. |
 | `position`, `velocity` | **1 — Spine** | Pose for simulation and replication. |
 | `user_data` | **2 — Replicated simulation** | Omitted from JSON when `null`. On the wire to neighbors and (current reference server) clients. |
-| `local_data` | **3 — Cluster-local** | **`#[serde(skip_serializing)]`** — never part of `EntityStateDelta` JSON. Not trusted from clients; set server-side. Incoming neighbor rows arrive with `local_data` defaulted / empty for that entity. |
+| `local_data` | **3 — Cluster-local** | **`skip_serializing` + `skip_deserializing`:** not on the wire; JSON must not hydrate bucket 3 from neighbors/Redis. Set only in-process. |
 
 ### 3.2 Per-tick simulation (optional)
 
@@ -53,7 +53,7 @@ Authoritative simulation may update **buckets 1–3** in memory each tick (pose,
 | Bucket | Who may write (production target) |
 |--------|-----------------------------------|
 | 1–2 | **Server / cluster authoritative simulation** after validating client **inputs**. Today’s reference WebSocket accepts `PLAYER_STATE` with pose and `user_data`; a production game should converge on **inputs → server sim** and treat client pose as cheat-prone unless locked down. |
-| 3 | **Only** cluster process (simulation, game code). Never accept `local_data` from a client message. |
+| 3 | **Only** cluster process (simulation, game code). Never accept `local_data` from a client message; replication JSON cannot populate it (`skip_deserializing` on the type). |
 | 4 | **SpacetimeDB reducers** and controlled server calls; clients subscribe, not mutate tables directly without module rules. |
 
 Document your game’s exact validation policy in your own design doc; this table is the Arcane platform contract.

--- a/docs/architecture/interface-ireplicationchannel.md
+++ b/docs/architecture/interface-ireplicationchannel.md
@@ -97,17 +97,16 @@ EntityStateDelta {
 }
 
 EntityStateEntry {
-  entity_id:       UUID
-  entity_type:     PLAYER | NPC | PROJECTILE | AOE_FIELD
-  position:        Vector3
-  velocity:        Vector3
-  facing:          Quaternion
-  animation_state: AnimState
-  health:          int
-  visual_tags:     string[]
-  dirty_fields:    bitmask      // which fields changed — skip unchanged
+  entity_id:    UUID
+  cluster_id:   UUID
+  position:     Vector3      // bucket 1 — spine
+  velocity:     Vector3      // bucket 1 — spine
+  user_data:    JSON | null  // bucket 2 — on wire when present (game-defined schema)
+  // local_data: JSON — bucket 3; not serialized on EntityStateDelta (cluster process only)
 }
 ```
+
+See `docs/architecture/four-bucket-state-model.md` for the full model. Game-specific fields (health, anim, etc.) typically live in **`user_data`** (replicated) or SpacetimeDB (**bucket 4**) until finer-grained wire types exist.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the **v1 four-bucket** model on the wire and in public types: `EntityStateEntry` gains `user_data` (replicated JSON) and `local_data` (cluster-local, never serialized on `EntityStateDelta`), plus `EntityStateEntry::new`.

## Docs

- `docs/architecture/four-bucket-state-model.md` — optional sim wording (no ClusterSimulation file dependency), workload pinning (§8), checklist updates.
- `docs/architecture/interface-ireplicationchannel.md` — `EntityStateEntry` sketch matches implementation.
- `CHANGELOG.md` — Unreleased entry.

## Infra

- WebSocket `PLAYER_STATE` accepts optional `user_data`; `local_data` is never read from clients.
- `spacetimedb_persist` module comment clarifies bucket 1 → 4 throttled mirror.

## Tests

`cargo test --all-features`

Tracks **#6** (external benchmarks/demos: pin crate + module versions per checklist §8 — follow-up outside this repo if needed).

## Not in this PR

- **#8** (physics / Unreal) — separate branch/PR.
- **Benchmark error taxonomy** (arcane-swarm / scaling-benchmarks README categories such as `timeout`, `not_delivered`, etc.) — **not** changed here; that work lives in **arcane-scaling-benchmarks** (and swarm), not in this `arcane` branch.
