### PR TITLE
feat(core): ClusterSimulation trait and simulate_before_tick hook

### DIFF
--- a/crates/arcane-core/src/cluster_simulation.rs
+++ b/crates/arcane-core/src/cluster_simulation.rs
@@ -1,0 +1,36 @@
+//! Pluggable per-tick simulation for cluster-owned entities (IN-02 extension).
+//!
+//! **Ephemeral-only state** (not replicated): keep it in fields on your `ClusterSimulation` type.
+//! **Replicated custom fields**: set [`crate::replication_channel::EntityStateEntry::user_data`] (JSON; default null).
+//! **Durable / transactional state**: SpacetimeDB reducers and tables, not this hook alone.
+//!
+//! Implement [`ClusterSimulation`] in your crate and pass `Some(Arc::new(...))` to
+//! `arcane_infra::cluster_runner::run_cluster_loop` (Cargo feature `cluster-ws` on `arcane-infra`).
+//! The hook runs
+//! after client updates and injected entities are applied, and before the replication delta is built.
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::replication_channel::EntityStateEntry;
+
+/// Mutable view of one tick's simulation inputs. Custom logic may update positions and velocities.
+///
+/// To despawn an entity, push its id to [`ClusterTickContext::pending_removals`]. The server will
+/// remove it and include the id in the next delta's `removed` list. Deleting from `entities` alone
+/// would omit the entity from `updated` without a removal record.
+pub struct ClusterTickContext<'a> {
+    pub cluster_id: Uuid,
+    /// Monotonic tick index that will be assigned to the upcoming replication delta's `tick` field.
+    pub tick: u64,
+    pub dt_seconds: f64,
+    pub entities: &'a mut HashMap<Uuid, EntityStateEntry>,
+    /// Processed after `on_tick` returns so the next delta lists these ids under `removed`.
+    pub pending_removals: &'a mut Vec<Uuid>,
+}
+
+/// Custom simulation step for entities owned by this cluster.
+pub trait ClusterSimulation: Send + Sync {
+    fn on_tick(&self, ctx: &mut ClusterTickContext<'_>);
+}

--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -14,8 +14,8 @@
 //! these contracts. `arcane-core` itself has no runtime side effects and should remain a dependency
 //! root for cross-crate compatibility.
 
-pub mod clustering_model;
 pub mod cluster_simulation;
+pub mod clustering_model;
 pub mod replication_channel;
 pub mod server_pool;
 pub mod types;

--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -15,11 +15,13 @@
 //! root for cross-crate compatibility.
 
 pub mod clustering_model;
+pub mod cluster_simulation;
 pub mod replication_channel;
 pub mod server_pool;
 pub mod types;
 pub mod world_simulator;
 
+pub use cluster_simulation::{ClusterSimulation, ClusterTickContext};
 pub use clustering_model::{
     ClusterDecision, ClusterInfo, DecisionReason, DecisionType, IClusteringModel, ModelInfo,
     PlayerInfo, ValidationResult, WorldStateView,

--- a/crates/arcane-infra/src/bin/arcane_cluster.rs
+++ b/crates/arcane-infra/src/bin/arcane_cluster.rs
@@ -11,7 +11,9 @@
 //!   CLUSTER_ID=550e8400-e29b-41d4-a716-446655440000 cargo run -p arcane-infra --bin arcane-cluster --features cluster-ws
 
 use std::env;
+use std::sync::Arc;
 
+use arcane_core::ClusterSimulation;
 use arcane_infra::cluster_runner;
 use uuid::Uuid;
 
@@ -47,6 +49,7 @@ fn main() -> Result<(), String> {
             neighbor_ids,
             ws_port,
             |_| vec![], // no demo entities; use arcane_cluster_demo from arcane-demo for that
+            Option::<Arc<dyn ClusterSimulation>>::None,
         )
     }
 

--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use arcane_core::cluster_simulation::ClusterSimulation;
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
@@ -49,6 +50,9 @@ fn merge_with_neighbor_latest(
 
 /// Runs the cluster server loop with WebSocket and Redis replication.
 /// Each tick, after applying client updates, calls `extra_entities_for_tick(tick_count)` and pushes any returned entries into the server (e.g. demo agents from arcane-demo).
+///
+/// When `simulation` is `Some`, [`ClusterSimulation::on_tick`] runs after those steps and before
+/// [`ClusterServer::tick`], using `1 / TICK_RATE_HZ` as `dt_seconds`.
 /// Never returns on success (infinite loop); returns Err only if setup fails.
 #[cfg(feature = "cluster-ws")]
 pub fn run_cluster_loop<F>(
@@ -57,6 +61,7 @@ pub fn run_cluster_loop<F>(
     neighbor_ids: Vec<Uuid>,
     ws_port: u16,
     mut extra_entities_for_tick: F,
+    simulation: Option<Arc<dyn ClusterSimulation>>,
 ) -> Result<(), String>
 where
     F: FnMut(u64) -> Vec<EntityStateEntry>,
@@ -89,6 +94,7 @@ where
     let persist = SpacetimeDbPersist::from_env();
 
     let interval = Duration::from_millis(1000 / TICK_RATE_HZ);
+    let dt_seconds = interval.as_secs_f64();
     let mut tick_count: u64 = 0;
 
     loop {
@@ -104,6 +110,12 @@ where
             neighbor_latest.insert(delta.source_cluster_id, delta.updated);
         }
         let tick_start = Instant::now();
+        let upcoming_tick = server.current_tick() + 1;
+        server.simulate_before_tick(
+            dt_seconds,
+            upcoming_tick,
+            simulation.as_ref().map(|s| s.as_ref()),
+        );
         let our_delta = server.tick();
         let tick_elapsed_ms = tick_start.elapsed().as_secs_f64() * 1000.0;
         let merged_delta = merge_with_neighbor_latest(our_delta, &neighbor_latest);

--- a/crates/arcane-infra/src/cluster_server.rs
+++ b/crates/arcane-infra/src/cluster_server.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
@@ -58,6 +59,35 @@ impl ClusterServer {
     /// Run the server loop (tick, SpacetimeDB, replication, WebSocket). Blocks.
     pub fn run(&self) -> Result<(), String> {
         Ok(())
+    }
+
+    /// Runs custom simulation with exclusive access to the local entity map, then applies any
+    /// [`ClusterTickContext::pending_removals`]. Call immediately before [`ClusterServer::tick`].
+    /// `upcoming_tick` must match the tick index the next `tick()` will assign (`current_tick() + 1`
+    /// before the first `tick()` call).
+    pub fn simulate_before_tick(
+        &self,
+        dt_seconds: f64,
+        upcoming_tick: u64,
+        simulation: Option<&dyn ClusterSimulation>,
+    ) {
+        let Some(sim) = simulation else {
+            return;
+        };
+        let mut pending_removals = Vec::new();
+        {
+            let mut entities = self.entities.lock().expect("entities lock");
+            sim.on_tick(&mut ClusterTickContext {
+                cluster_id: self.cluster_id,
+                tick: upcoming_tick,
+                dt_seconds,
+                entities: &mut *entities,
+                pending_removals: &mut pending_removals,
+            });
+        }
+        for id in pending_removals {
+            self.remove_entity(id);
+        }
     }
 
     /// Advance simulation by one tick, build delta from current entities, broadcast to neighbors if set, and return the delta.

--- a/crates/arcane-infra/src/cluster_server.rs
+++ b/crates/arcane-infra/src/cluster_server.rs
@@ -81,7 +81,7 @@ impl ClusterServer {
                 cluster_id: self.cluster_id,
                 tick: upcoming_tick,
                 dt_seconds,
-                entities: &mut *entities,
+                entities: &mut entities,
                 pending_removals: &mut pending_removals,
             });
         }

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -26,6 +26,9 @@ pub mod cluster_runner;
 #[cfg(feature = "cluster-ws")]
 pub mod ws_server;
 
+#[cfg(feature = "cluster-ws")]
+pub use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
+
 pub use cluster_manager::ClusterManager;
 pub use cluster_server::ClusterServer;
 pub use redis_channel::RedisReplicationChannel;

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -167,6 +167,7 @@ mod tests {
         assert_eq!(parsed.entity_id, id);
         assert_eq!(parsed.position.x, 1.0);
         assert_eq!(parsed.velocity.z, 0.3);
+        assert!(parsed.user_data.is_null());
     }
 
     #[test]

--- a/crates/arcane-infra/tests/cluster_server_tests.rs
+++ b/crates/arcane-infra/tests/cluster_server_tests.rs
@@ -2,8 +2,18 @@
 
 use std::sync::Arc;
 
-use arcane_infra::{ClusterServer, ReplicationChannelManager};
+use arcane_infra::{ClusterServer, ClusterSimulation, ReplicationChannelManager};
 use uuid::Uuid;
+
+struct NudgePositiveX;
+
+impl ClusterSimulation for NudgePositiveX {
+    fn on_tick(&self, ctx: &mut arcane_infra::ClusterTickContext<'_>) {
+        for e in ctx.entities.values_mut() {
+            e.position.x += 10.0 * ctx.dt_seconds;
+        }
+    }
+}
 
 #[test]
 fn new_holds_cluster_id() {
@@ -81,6 +91,86 @@ fn tick_returns_delta_with_entities() {
     assert_eq!(delta.updated[0].position.y, 2.0);
     assert_eq!(delta.updated[0].position.z, 3.0);
     assert!(delta.removed.is_empty());
+}
+
+#[test]
+fn simulate_before_tick_runs_before_delta_and_sees_upcoming_tick() {
+    use arcane_core::replication_channel::EntityStateEntry;
+    use arcane_core::Vec3;
+
+    struct RecordTick;
+    impl ClusterSimulation for RecordTick {
+        fn on_tick(&self, ctx: &mut arcane_infra::ClusterTickContext<'_>) {
+            assert_eq!(ctx.tick, 1, "first frame should use upcoming tick 1");
+            assert!((ctx.dt_seconds - 0.05).abs() < 1e-9);
+            let _ = ctx
+                .entities
+                .get_mut(&Uuid::nil())
+                .expect("entity present")
+                .position
+                .x;
+        }
+    }
+
+    let cluster_id = Uuid::new_v4();
+    let server = ClusterServer::new(cluster_id);
+    server.add_entity(EntityStateEntry::new(
+        Uuid::nil(),
+        cluster_id,
+        Vec3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 0.0),
+    ));
+    server.simulate_before_tick(0.05, 1, Some(&RecordTick));
+    let delta = server.tick();
+    assert_eq!(delta.tick, 1);
+}
+
+#[test]
+fn simulate_before_tick_can_mutate_positions() {
+    use arcane_core::replication_channel::EntityStateEntry;
+    use arcane_core::Vec3;
+
+    let cluster_id = Uuid::new_v4();
+    let server = ClusterServer::new(cluster_id);
+    let entity_id = Uuid::new_v4();
+    server.add_entity(EntityStateEntry::new(
+        entity_id,
+        cluster_id,
+        Vec3::new(0.0, 0.0, 0.0),
+        Vec3::new(1.0, 0.0, 0.0),
+    ));
+    server.simulate_before_tick(1.0, 1, Some(&NudgePositiveX));
+    let delta = server.tick();
+    assert_eq!(delta.updated[0].position.x, 10.0);
+}
+
+#[test]
+fn simulate_before_tick_pending_removals_end_up_in_delta_removed() {
+    use arcane_core::replication_channel::EntityStateEntry;
+    use arcane_core::Vec3;
+
+    struct RemoveAll;
+    impl ClusterSimulation for RemoveAll {
+        fn on_tick(&self, ctx: &mut arcane_infra::ClusterTickContext<'_>) {
+            for id in ctx.entities.keys().copied().collect::<Vec<_>>() {
+                ctx.pending_removals.push(id);
+            }
+        }
+    }
+
+    let cluster_id = Uuid::new_v4();
+    let server = ClusterServer::new(cluster_id);
+    let entity_id = Uuid::new_v4();
+    server.add_entity(EntityStateEntry::new(
+        entity_id,
+        cluster_id,
+        Vec3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, 0.0),
+    ));
+    server.simulate_before_tick(0.05, 1, Some(&RemoveAll));
+    let delta = server.tick();
+    assert!(delta.updated.is_empty());
+    assert_eq!(delta.removed, vec![entity_id]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `ClusterSimulation` trait and `ClusterTickContext` to `arcane-core` — the pluggable per-tick simulation hook for cluster-owned entities
- Adds `ClusterServer::simulate_before_tick()` — runs custom logic with exclusive entity access before building the replication delta
- Updates `run_cluster_loop` to accept `Option<Arc<dyn ClusterSimulation>>`
- `arcane-cluster` binary passes `None` (games supply their own impl)

## Why

Cluster servers need authoritative physics/game logic injected into the tick loop. Without this, clusters only relay client positions — no server-side simulation. This is required for fair benchmarks (equivalent workload to SpacetimeDB's `physics_tick` reducer) and for production use.

## How it works

1. Game implements `ClusterSimulation::on_tick(&self, ctx: &mut ClusterTickContext)`
2. Passes `Some(Arc::new(MySimulation))` to `run_cluster_loop`
3. Hook runs **after** client updates are applied, **before** `ClusterServer::tick()` builds the delta
4. `ClusterTickContext` gives mutable access to all entities + pending removals list

## Test plan

- [x] `simulate_before_tick_runs_before_delta_and_sees_upcoming_tick`
- [x] `simulate_before_tick_can_mutate_positions`
- [x] `simulate_before_tick_pending_removals_end_up_in_delta_removed`
- [x] All 62 existing tests pass (`cargo test --workspace --all-features`)

Partial progress on #8 (trait and hook only; physics backends follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)