### PR TITLE
chore: add source-available license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "crates/arcane-pool",
     "crates/arcane-infra",
 ]
+
+[workspace.package]
+license-file = "LICENSE"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Arcane Engine — Source Available License
+
+Copyright (c) 2026 Brainy Bots Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to view,
+read, fork, and build the Software for the sole purposes of evaluation,
+testing, education, and non-commercial research.
+
+The following uses require a separate commercial license from Brainy Bots Inc.:
+
+  - Using the Software, or any derivative work, in production environments
+  - Incorporating the Software into a commercial product or service
+  - Offering the Software, or a derivative work, as a hosted or managed service
+  - Distributing the Software, or a derivative work, for commercial purposes
+
+Contributions submitted to this repository are licensed under the same terms
+and assign Brainy Bots Inc. the right to relicense contributed code.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For commercial licensing inquiries, contact: martin.mba@gmail.com

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ See [arcane-demos](https://github.com/brainy-bots/arcane-demos) for a full demo 
 
 The Unreal Engine client plugin lives in a separate repo: **arcane-client-unreal**. Add it to your project's `Plugins/` folder.
 
+## License
+
+Arcane is **source-available**. You may view, evaluate, and build the code for non-commercial purposes. Production use, commercial distribution, and managed service offerings require a commercial license from Brainy Bots Inc. See [LICENSE](LICENSE) for details.
+
+For licensing inquiries: martin.mba@gmail.com
+
 ## Versioning
 
 Releases are tagged (e.g. `v0.1.0`). See [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
## Summary

Adds a source-available license before making the repo public.

**Permitted:** View, read, fork, build for evaluation, testing, education, and non-commercial research.

**Requires commercial license:** Production use, commercial products, managed services, commercial distribution.

- LICENSE file added to repo root
- `license-file = "LICENSE"` in workspace Cargo.toml
- License section added to README with contact email

🤖 Generated with [Claude Code](https://claude.com/claude-code)