### PR TITLE
chore: switch to BSL 1.1 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,59 @@
-Arcane Engine — Source Available License
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-Copyright (c) 2026 Brainy Bots Inc. All rights reserved.
+Parameters
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to view,
-read, fork, and build the Software for the sole purposes of evaluation,
-testing, education, and non-commercial research.
+Licensor:             Brainy Bots Inc.
+Licensed Work:        Arcane Engine v0.1.0 or later.
+                      The Licensed Work is (c) 2026 Brainy Bots Inc.
+Additional Use Grant: None
+Change Date:          April 17, 2036
+Change License:       Apache 2.0
 
-The following uses require a separate commercial license from Brainy Bots Inc.:
+For information about alternative licensing arrangements for the Licensed Work,
+please contact martin.mba@gmail.com.
 
-  - Using the Software, or any derivative work, in production environments
-  - Incorporating the Software into a commercial product or service
-  - Offering the Software, or a derivative work, as a hosted or managed service
-  - Distributing the Software, or a derivative work, for commercial purposes
+Notice
 
-Contributions submitted to this repository are licensed under the same terms
-and assign Brainy Bots Inc. the right to relicense contributed code.
+Business Source License 1.1
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Terms
 
-For commercial licensing inquiries, contact: martin.mba@gmail.com
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the tenth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ The Unreal Engine client plugin lives in a separate repo: **arcane-client-unreal
 
 ## License
 
-Arcane is **source-available**. You may view, evaluate, and build the code for non-commercial purposes. Production use, commercial distribution, and managed service offerings require a commercial license from Brainy Bots Inc. See [LICENSE](LICENSE) for details.
+Arcane is licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1). You may copy, modify, and use the code for non-production purposes. Production use requires a commercial license from Brainy Bots Inc.
 
-For licensing inquiries: martin.mba@gmail.com
+On April 17, 2036, this version converts to Apache 2.0.
+
+For commercial licensing: martin.mba@gmail.com
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Replace custom source-available license with the standard **Business Source License 1.1** (BSL 1.1).

**Parameters:**
- **Licensor:** Brainy Bots Inc.
- **Licensed Work:** Arcane Engine v0.1.0 or later
- **Additional Use Grant:** None
- **Change Date:** April 17, 2036 (10 years)
- **Change License:** Apache 2.0

Non-production use is free. Production use requires a commercial license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)