### PR TITLE
feat(infra): WebSocket game actions and GameAction type

### DIFF
--- a/crates/arcane-core/src/cluster_simulation.rs
+++ b/crates/arcane-core/src/cluster_simulation.rs
@@ -8,12 +8,36 @@
 //! `arcane_infra::cluster_runner::run_cluster_loop` (Cargo feature `cluster-ws` on `arcane-infra`).
 //! The hook runs
 //! after client updates and injected entities are applied, and before the replication delta is built.
+//!
+//! ## Game actions
+//!
+//! Clients may send simulation-affecting game actions (e.g., "use item", "cast spell") via
+//! WebSocket. These arrive as [`GameAction`] values in [`ClusterTickContext::game_actions`].
+//! The simulation decides what to do: validate through SpacetimeDB, apply buffs, etc.
+//! Non-simulation actions (cosmetics, chat, quests) go direct from client to SpacetimeDB
+//! and never reach the cluster.
 
 use std::collections::HashMap;
 
 use uuid::Uuid;
 
 use crate::replication_channel::EntityStateEntry;
+
+/// A game action sent by a client through the cluster WebSocket. The cluster's
+/// [`ClusterSimulation`] processes these — typically by validating through SpacetimeDB
+/// and applying simulation effects (buffs, roots, damage).
+///
+/// The `action_type` and `payload` are game-defined. The library does not interpret them.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct GameAction {
+    /// Which entity (player) is performing the action.
+    pub entity_id: Uuid,
+    /// Game-defined action type (e.g., "use_item", "cast_spell", "interact").
+    pub action_type: String,
+    /// Game-defined payload (e.g., `{"item_type": 5}` or `{"target_id": "uuid"}`).
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
 
 /// Mutable view of one tick's simulation inputs. Custom logic may update positions and velocities.
 ///
@@ -28,6 +52,9 @@ pub struct ClusterTickContext<'a> {
     pub entities: &'a mut HashMap<Uuid, EntityStateEntry>,
     /// Processed after `on_tick` returns so the next delta lists these ids under `removed`.
     pub pending_removals: &'a mut Vec<Uuid>,
+    /// Game actions received from clients this tick. The simulation processes these — the library
+    /// does not interpret them. Drained each tick (actions not consumed are discarded).
+    pub game_actions: &'a [GameAction],
 }
 
 /// Custom simulation step for entities owned by this cluster.

--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod server_pool;
 pub mod types;
 pub mod world_simulator;
 
-pub use cluster_simulation::{ClusterSimulation, ClusterTickContext};
+pub use cluster_simulation::{ClusterSimulation, ClusterTickContext, GameAction};
 pub use clustering_model::{
     ClusterDecision, ClusterInfo, DecisionReason, DecisionType, IClusteringModel, ModelInfo,
     PlayerInfo, ValidationResult, WorldStateView,

--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use arcane_core::cluster_simulation::ClusterSimulation;
+use arcane_core::cluster_simulation::{ClusterSimulation, GameAction};
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
@@ -77,7 +77,8 @@ where
 
     let (state_tx, state_rx) = std::sync::mpsc::channel();
     let (client_updates_tx, client_updates_rx) = std::sync::mpsc::channel();
-    crate::ws_server::run_ws_server(ws_port, state_rx, client_updates_tx);
+    let (game_actions_tx, game_actions_rx) = std::sync::mpsc::channel::<GameAction>();
+    crate::ws_server::run_ws_server(ws_port, state_rx, client_updates_tx, game_actions_tx);
 
     let (neighbor_tx, neighbor_rx) = std::sync::mpsc::channel::<EntityStateDelta>();
     spawn_neighbor_subscriber(redis_url.clone(), neighbor_ids.clone(), neighbor_tx);
@@ -109,12 +110,17 @@ where
         while let Ok(delta) = neighbor_rx.try_recv() {
             neighbor_latest.insert(delta.source_cluster_id, delta.updated);
         }
+        let mut tick_actions: Vec<GameAction> = Vec::new();
+        while let Ok(action) = game_actions_rx.try_recv() {
+            tick_actions.push(action);
+        }
         let tick_start = Instant::now();
         let upcoming_tick = server.current_tick() + 1;
         server.simulate_before_tick(
             dt_seconds,
             upcoming_tick,
             simulation.as_ref().map(|s| s.as_ref()),
+            &tick_actions,
         );
         let our_delta = server.tick();
         let tick_elapsed_ms = tick_start.elapsed().as_secs_f64() * 1000.0;

--- a/crates/arcane-infra/src/cluster_server.rs
+++ b/crates/arcane-infra/src/cluster_server.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
+use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext, GameAction};
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
@@ -74,11 +74,15 @@ impl ClusterServer {
     /// [`ClusterTickContext::pending_removals`]. Call immediately before [`ClusterServer::tick`].
     /// `upcoming_tick` must match the tick index the next `tick()` will assign (`current_tick() + 1`
     /// before the first `tick()` call).
+    ///
+    /// `game_actions` contains client actions received since the last tick. The simulation
+    /// decides how to handle them (e.g., validate through SpacetimeDB, apply buffs).
     pub fn simulate_before_tick(
         &self,
         dt_seconds: f64,
         upcoming_tick: u64,
         simulation: Option<&dyn ClusterSimulation>,
+        game_actions: &[GameAction],
     ) {
         let Some(sim) = simulation else {
             return;
@@ -92,6 +96,7 @@ impl ClusterServer {
                 dt_seconds,
                 entities: &mut entities,
                 pending_removals: &mut pending_removals,
+                game_actions,
             });
         }
         for id in pending_removals {

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -27,7 +27,7 @@ pub mod cluster_runner;
 pub mod ws_server;
 
 #[cfg(feature = "cluster-ws")]
-pub use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
+pub use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext, GameAction};
 
 pub use cluster_manager::ClusterManager;
 pub use cluster_server::ClusterServer;

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -9,6 +9,7 @@
 use std::net::SocketAddr;
 use std::sync::mpsc::{Receiver, Sender};
 
+use arcane_core::cluster_simulation::GameAction;
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use arcane_core::Vec3;
 use futures_util::{sink::SinkExt, stream::StreamExt};
@@ -67,6 +68,41 @@ fn parse_player_state(text: &str) -> Option<EntityStateEntry> {
     Some(entry)
 }
 
+/// Generic incoming WebSocket message — we peek at "type" to decide how to route it.
+#[derive(serde::Deserialize)]
+struct TypePeek {
+    #[serde(rename = "type")]
+    msg_type: String,
+}
+
+/// Parse a game action message. Expects JSON:
+/// `{"type":"GAME_ACTION","entity_id":"uuid","action_type":"use_item","payload":{...}}`.
+fn parse_game_action(text: &str) -> Option<GameAction> {
+    if text.len() > MAX_MESSAGE_BYTES {
+        return None;
+    }
+    serde_json::from_str::<GameAction>(text).ok()
+}
+
+/// Result of parsing an incoming WebSocket text message.
+enum ClientMessage {
+    PlayerState(EntityStateEntry),
+    Action(GameAction),
+}
+
+/// Route an incoming WebSocket text message to the appropriate type.
+fn parse_client_message(text: &str) -> Option<ClientMessage> {
+    if text.len() > MAX_MESSAGE_BYTES {
+        return None;
+    }
+    let peek: TypePeek = serde_json::from_str(text).ok()?;
+    match peek.msg_type.as_str() {
+        "PLAYER_STATE" => parse_player_state(text).map(ClientMessage::PlayerState),
+        "GAME_ACTION" => parse_game_action(text).map(ClientMessage::Action),
+        _ => None,
+    }
+}
+
 fn should_keep_ws_loop_running_on_broadcast_error(
     error: &tokio::sync::broadcast::error::RecvError,
 ) -> bool {
@@ -77,13 +113,14 @@ pub fn run_ws_server(
     port: u16,
     state_rx: Receiver<EntityStateDelta>,
     client_updates_tx: Sender<EntityStateEntry>,
+    game_actions_tx: Sender<GameAction>,
 ) {
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("tokio runtime");
-        rt.block_on(ws_loop(port, state_rx, client_updates_tx));
+        rt.block_on(ws_loop(port, state_rx, client_updates_tx, game_actions_tx));
     });
 }
 
@@ -91,6 +128,7 @@ async fn ws_loop(
     port: u16,
     state_rx: Receiver<EntityStateDelta>,
     client_updates_tx: Sender<EntityStateEntry>,
+    game_actions_tx: Sender<GameAction>,
 ) {
     let (broadcast_tx, _) = tokio::sync::broadcast::channel::<String>(256);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -127,6 +165,7 @@ async fn ws_loop(
         };
         let mut recv = broadcast_tx.subscribe();
         let updates_tx = client_updates_tx.clone();
+        let actions_tx = game_actions_tx.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -149,8 +188,14 @@ async fn ws_loop(
                     msg = ws_stream.next() => {
                         match msg {
                             Some(Ok(Message::Text(text))) => {
-                                if let Some(entry) = parse_player_state(&text) {
-                                    let _ = updates_tx.send(entry);
+                                match parse_client_message(&text) {
+                                    Some(ClientMessage::PlayerState(entry)) => {
+                                        let _ = updates_tx.send(entry);
+                                    }
+                                    Some(ClientMessage::Action(action)) => {
+                                        let _ = actions_tx.send(action);
+                                    }
+                                    None => {}
                                 }
                             }
                             Some(Err(_)) | None => break,
@@ -165,7 +210,10 @@ async fn ws_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_player_state, should_keep_ws_loop_running_on_broadcast_error};
+    use super::{
+        parse_client_message, parse_game_action, parse_player_state,
+        should_keep_ws_loop_running_on_broadcast_error, ClientMessage,
+    };
     use tokio::sync::broadcast::error::RecvError;
     use uuid::Uuid;
 
@@ -253,6 +301,54 @@ mod tests {
             id, big_data
         );
         assert!(parse_player_state(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_game_action_accepts_valid_payload() {
+        let id = Uuid::from_u128(10);
+        let payload = format!(
+            r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"use_item","payload":{{"item_type":5}}}}"#,
+            id
+        );
+        let action = parse_game_action(&payload).expect("valid game action");
+        assert_eq!(action.entity_id, id);
+        assert_eq!(action.action_type, "use_item");
+        assert_eq!(action.payload, serde_json::json!({"item_type": 5}));
+    }
+
+    #[test]
+    fn parse_client_message_routes_player_state() {
+        let id = Uuid::from_u128(1);
+        let payload = format!(
+            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":1.0,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}}}}"#,
+            id
+        );
+        match parse_client_message(&payload) {
+            Some(ClientMessage::PlayerState(e)) => assert_eq!(e.entity_id, id),
+            _ => panic!("expected PlayerState"),
+        }
+    }
+
+    #[test]
+    fn parse_client_message_routes_game_action() {
+        let id = Uuid::from_u128(20);
+        let payload = format!(
+            r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"cast_spell","payload":{{}}}}"#,
+            id
+        );
+        match parse_client_message(&payload) {
+            Some(ClientMessage::Action(a)) => {
+                assert_eq!(a.entity_id, id);
+                assert_eq!(a.action_type, "cast_spell");
+            }
+            _ => panic!("expected Action"),
+        }
+    }
+
+    #[test]
+    fn parse_client_message_rejects_unknown_type() {
+        let payload = r#"{"type":"UNKNOWN","data":"foo"}"#;
+        assert!(parse_client_message(payload).is_none());
     }
 
     #[test]

--- a/crates/arcane-infra/tests/cluster_server_tests.rs
+++ b/crates/arcane-infra/tests/cluster_server_tests.rs
@@ -120,7 +120,7 @@ fn simulate_before_tick_runs_before_delta_and_sees_upcoming_tick() {
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(0.0, 0.0, 0.0),
     ));
-    server.simulate_before_tick(0.05, 1, Some(&RecordTick));
+    server.simulate_before_tick(0.05, 1, Some(&RecordTick), &[]);
     let delta = server.tick();
     assert_eq!(delta.tick, 1);
 }
@@ -139,7 +139,7 @@ fn simulate_before_tick_can_mutate_positions() {
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(1.0, 0.0, 0.0),
     ));
-    server.simulate_before_tick(1.0, 1, Some(&NudgePositiveX));
+    server.simulate_before_tick(1.0, 1, Some(&NudgePositiveX), &[]);
     let delta = server.tick();
     assert_eq!(delta.updated[0].position.x, 10.0);
 }
@@ -167,7 +167,7 @@ fn simulate_before_tick_pending_removals_end_up_in_delta_removed() {
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(0.0, 0.0, 0.0),
     ));
-    server.simulate_before_tick(0.05, 1, Some(&RemoveAll));
+    server.simulate_before_tick(0.05, 1, Some(&RemoveAll), &[]);
     let delta = server.tick();
     assert!(delta.updated.is_empty());
     assert_eq!(delta.removed, vec![entity_id]);
@@ -276,7 +276,7 @@ fn simulate_before_tick_panicking_simulation_poisons_but_does_not_cascade() {
     ));
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        server.simulate_before_tick(0.05, 1, Some(&PanicSim));
+        server.simulate_before_tick(0.05, 1, Some(&PanicSim), &[]);
     }));
     assert!(result.is_err(), "panicking simulation should propagate");
     // After a panic, the entities lock is poisoned — tick() will also panic.


### PR DESCRIPTION
## Summary

Adds support for clients to send simulation-affecting game actions through the cluster WebSocket, alongside movement updates.

### Changes

- **arcane-core:** `GameAction` struct (entity_id, action_type, payload JSON). `ClusterTickContext` gains `game_actions` field.
- **arcane-infra ws_server:** Parses `GAME_ACTION` messages and routes them to a separate channel. `PLAYER_STATE` routing unchanged.
- **arcane-infra cluster_runner:** Drains game actions each tick, passes to `simulate_before_tick`.
- **arcane-infra cluster_server:** `simulate_before_tick` accepts `&[GameAction]` and passes to `ClusterTickContext`.

### Protocol

Clients send JSON over the existing WebSocket:
```json
{"type": "GAME_ACTION", "entity_id": "uuid", "action_type": "use_item", "payload": {"item_type": 5}}
```

The library does not interpret game actions — the `ClusterSimulation` decides what to do (validate through SpacetimeDB, apply buffs, etc.).

### Developer pattern
- **Simulation-affecting actions** (speed potion, cast spell): Client → Cluster → SpacetimeDB
- **Non-simulation actions** (cosmetic, chat, quest): Client → SpacetimeDB direct

See `docs/architecture/connection-types.md` (PR #15) for full documentation.

### Test plan
- [x] `parse_game_action_accepts_valid_payload`
- [x] `parse_client_message_routes_player_state`
- [x] `parse_client_message_routes_game_action`
- [x] `parse_client_message_rejects_unknown_type`
- [x] All 76 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)