### PR TITLE
feat(infra): cluster stats counters + /stats HTTP endpoint

### DIFF
--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -13,10 +13,14 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use std::sync::atomic::Ordering;
+
 use arcane_core::cluster_simulation::{ClusterSimulation, GameAction};
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
+#[cfg(feature = "cluster-ws")]
+use crate::cluster_stats::{serve_stats_http, ClusterStats};
 #[cfg(feature = "cluster-ws")]
 use crate::neighbor_subscriber::spawn_neighbor_subscriber;
 #[cfg(feature = "spacetimedb-persist")]
@@ -78,7 +82,21 @@ where
     let (state_tx, state_rx) = std::sync::mpsc::channel();
     let (client_updates_tx, client_updates_rx) = std::sync::mpsc::channel();
     let (game_actions_tx, game_actions_rx) = std::sync::mpsc::channel::<GameAction>();
-    crate::ws_server::run_ws_server(ws_port, state_rx, client_updates_tx, game_actions_tx);
+
+    let stats = ClusterStats::new();
+    let stats_port = std::env::var("CLUSTER_STATS_PORT")
+        .ok()
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(ws_port.saturating_add(1));
+    serve_stats_http(stats_port, cluster_id.to_string(), stats.clone());
+
+    crate::ws_server::run_ws_server(
+        ws_port,
+        state_rx,
+        client_updates_tx,
+        game_actions_tx,
+        stats.clone(),
+    );
 
     let (neighbor_tx, neighbor_rx) = std::sync::mpsc::channel::<EntityStateDelta>();
     spawn_neighbor_subscriber(redis_url.clone(), neighbor_ids.clone(), neighbor_tx);
@@ -123,7 +141,8 @@ where
             &tick_actions,
         );
         let our_delta = server.tick();
-        let tick_elapsed_ms = tick_start.elapsed().as_secs_f64() * 1000.0;
+        let tick_elapsed = tick_start.elapsed();
+        let tick_elapsed_ms = tick_elapsed.as_secs_f64() * 1000.0;
         let merged_delta = merge_with_neighbor_latest(our_delta, &neighbor_latest);
         #[cfg(feature = "spacetimedb-persist")]
         if let Some(ref persist) = persist {
@@ -131,6 +150,15 @@ where
         }
 
         let _ = state_tx.send(merged_delta);
+
+        stats.set_entities(server.entity_count() as u64);
+        stats.tick.store(server.current_tick(), Ordering::Relaxed);
+        stats
+            .seq
+            .store(server.current_seq() as u64, Ordering::Relaxed);
+        stats
+            .last_tick_us
+            .store(tick_elapsed.as_micros() as u64, Ordering::Relaxed);
 
         tick_count += 1;
         if tick_count.is_multiple_of(LOG_EVERY_TICKS) {
@@ -143,9 +171,18 @@ where
         if tick_count.is_multiple_of(LOG_STATS_EVERY_TICKS) {
             let entities = server.entity_count();
             let clusters = 1u32; // This process is one cluster; multi-cluster = multiple processes
+            // Extended ArcaneServerStats: adds ws_accepts / msgs / parse_failures so log-only
+            // analysis (no /stats query) can still surface silent failures.
             eprintln!(
-                "ArcaneServerStats: entities={} clusters={} tick_ms={:.2}",
-                entities, clusters, tick_elapsed_ms
+                "ArcaneServerStats: entities={} clusters={} tick_ms={:.2} ws_accepts={} msgs_ps={} msgs_ga={} parse_fail={} bytes_in={}",
+                entities,
+                clusters,
+                tick_elapsed_ms,
+                stats.ws_accepts.load(Ordering::Relaxed),
+                stats.msgs_player_state.load(Ordering::Relaxed),
+                stats.msgs_game_action.load(Ordering::Relaxed),
+                stats.parse_failures.load(Ordering::Relaxed),
+                stats.bytes_in.load(Ordering::Relaxed),
             );
         }
         thread::sleep(interval);

--- a/crates/arcane-infra/src/cluster_stats.rs
+++ b/crates/arcane-infra/src/cluster_stats.rs
@@ -1,0 +1,184 @@
+//! Per-cluster runtime counters exposed to the benchmark harness (and anyone else
+//! who wants to verify the cluster is actually processing client traffic).
+//!
+//! The `ArcaneServerStats` log line has been the only observability signal until
+//! now, which lets silent failures (e.g. zero client messages accepted) pass as
+//! "successful" runs. This struct pairs with `serve_stats_http` below to expose
+//! the same counters over an HTTP `/stats` endpoint on a separate port, so the
+//! driver can cross-check "the swarm claims to have sent N messages" against
+//! "each cluster actually accepted K of them".
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct ClusterStats {
+    /// WebSocket connections accepted by this cluster's server socket since startup.
+    pub ws_accepts: AtomicU64,
+    /// PLAYER_STATE messages successfully parsed and forwarded to the cluster.
+    pub msgs_player_state: AtomicU64,
+    /// GAME_ACTION messages successfully parsed and forwarded to the cluster.
+    pub msgs_game_action: AtomicU64,
+    /// Incoming text messages that did not parse as either PLAYER_STATE or GAME_ACTION.
+    pub parse_failures: AtomicU64,
+    /// Inbound text bytes received by this cluster's WebSocket server.
+    pub bytes_in: AtomicU64,
+    /// Current entity count observed at the end of the most recent tick.
+    pub entities_current: AtomicU64,
+    /// Peak entity count observed since startup.
+    pub entities_peak: AtomicU64,
+    /// Most recent full tick number (see ClusterServer::current_tick).
+    pub tick: AtomicU64,
+    /// Most recent replication sequence (see ClusterServer::current_seq).
+    pub seq: AtomicU64,
+    /// Most recent tick elapsed time, in microseconds, for quick health signaling.
+    pub last_tick_us: AtomicU64,
+}
+
+impl ClusterStats {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn set_entities(&self, n: u64) {
+        self.entities_current.store(n, Ordering::Relaxed);
+        let mut peak = self.entities_peak.load(Ordering::Relaxed);
+        while n > peak {
+            match self.entities_peak.compare_exchange_weak(
+                peak,
+                n,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => peak = observed,
+            }
+        }
+    }
+
+    /// Render a flat JSON body for the HTTP stats endpoint. Kept small on purpose
+    /// so the harness's SSM/poll path is cheap.
+    pub fn to_json(&self, cluster_id: &str) -> String {
+        format!(
+            r#"{{"cluster_id":"{}","ws_accepts":{},"msgs_player_state":{},"msgs_game_action":{},"parse_failures":{},"bytes_in":{},"entities_current":{},"entities_peak":{},"tick":{},"seq":{},"last_tick_us":{}}}"#,
+            cluster_id,
+            self.ws_accepts.load(Ordering::Relaxed),
+            self.msgs_player_state.load(Ordering::Relaxed),
+            self.msgs_game_action.load(Ordering::Relaxed),
+            self.parse_failures.load(Ordering::Relaxed),
+            self.bytes_in.load(Ordering::Relaxed),
+            self.entities_current.load(Ordering::Relaxed),
+            self.entities_peak.load(Ordering::Relaxed),
+            self.tick.load(Ordering::Relaxed),
+            self.seq.load(Ordering::Relaxed),
+            self.last_tick_us.load(Ordering::Relaxed),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn set_entities_tracks_peak() {
+        let s = ClusterStats::new();
+        s.set_entities(10);
+        s.set_entities(5);
+        s.set_entities(20);
+        s.set_entities(15);
+        assert_eq!(s.entities_current.load(Ordering::Relaxed), 15);
+        assert_eq!(s.entities_peak.load(Ordering::Relaxed), 20);
+    }
+
+    #[test]
+    fn to_json_includes_all_counters() {
+        let s = ClusterStats::new();
+        s.ws_accepts.store(3, Ordering::Relaxed);
+        s.msgs_player_state.store(100, Ordering::Relaxed);
+        s.msgs_game_action.store(7, Ordering::Relaxed);
+        s.parse_failures.store(2, Ordering::Relaxed);
+        s.bytes_in.store(12345, Ordering::Relaxed);
+        s.set_entities(42);
+        s.tick.store(500, Ordering::Relaxed);
+        s.seq.store(501, Ordering::Relaxed);
+        s.last_tick_us.store(780, Ordering::Relaxed);
+        let json = s.to_json("abc-123");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["cluster_id"], "abc-123");
+        assert_eq!(parsed["ws_accepts"], 3);
+        assert_eq!(parsed["msgs_player_state"], 100);
+        assert_eq!(parsed["msgs_game_action"], 7);
+        assert_eq!(parsed["parse_failures"], 2);
+        assert_eq!(parsed["bytes_in"], 12345);
+        assert_eq!(parsed["entities_current"], 42);
+        assert_eq!(parsed["entities_peak"], 42);
+        assert_eq!(parsed["tick"], 500);
+        assert_eq!(parsed["seq"], 501);
+        assert_eq!(parsed["last_tick_us"], 780);
+    }
+}
+
+/// Minimal HTTP server that returns `stats.to_json(cluster_id)` on GET `/stats`
+/// and a liveness blob on `/`. Binds on `0.0.0.0:<port>` and never returns; run
+/// in its own OS thread with a private Tokio runtime.
+///
+/// Intentionally hand-rolled (not axum) to avoid adding a dependency to the
+/// `cluster-ws` feature. The protocol is one request, one response, no
+/// framing — enough for a counters endpoint.
+#[cfg(feature = "cluster-ws")]
+pub fn serve_stats_http(port: u16, cluster_id: String, stats: Arc<ClusterStats>) {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("stats tokio runtime");
+        rt.block_on(async move {
+            let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+            let listener = match tokio::net::TcpListener::bind(addr).await {
+                Ok(l) => l,
+                Err(e) => {
+                    eprintln!("cluster stats HTTP bind failed on {}: {}", addr, e);
+                    return;
+                }
+            };
+            eprintln!("cluster stats HTTP listening on http://{}/stats", addr);
+
+            loop {
+                let (socket, _peer) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                let stats = stats.clone();
+                let cluster_id = cluster_id.clone();
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut socket = socket;
+                    let mut buf = [0u8; 1024];
+                    let n = match socket.read(&mut buf).await {
+                        Ok(n) if n > 0 => n,
+                        _ => return,
+                    };
+                    let req = &buf[..n];
+                    let body = if req.starts_with(b"GET /stats") {
+                        stats.to_json(&cluster_id)
+                    } else if req.starts_with(b"GET / ") {
+                        format!(r#"{{"ok":true,"cluster_id":"{}"}}"#, cluster_id)
+                    } else {
+                        let _ = socket
+                            .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                            .await;
+                        return;
+                    };
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = socket.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+    });
+}

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -24,6 +24,8 @@ pub mod spacetimedb_persist;
 #[cfg(feature = "cluster-ws")]
 pub mod cluster_runner;
 #[cfg(feature = "cluster-ws")]
+pub mod cluster_stats;
+#[cfg(feature = "cluster-ws")]
 pub mod ws_server;
 
 #[cfg(feature = "cluster-ws")]

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -7,7 +7,9 @@
 //! never taken from the client; it stays default until the cluster sets it server-side.
 
 use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
 use std::sync::mpsc::{Receiver, Sender};
+use std::sync::Arc;
 
 use arcane_core::cluster_simulation::GameAction;
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
@@ -16,6 +18,8 @@ use futures_util::{sink::SinkExt, stream::StreamExt};
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
+
+use crate::cluster_stats::ClusterStats;
 
 /// Incoming message from a client. Expects JSON:
 /// `{"type":"PLAYER_STATE","entity_id":"uuid","position":{...},"velocity":{...},"user_data":?}`.
@@ -114,13 +118,20 @@ pub fn run_ws_server(
     state_rx: Receiver<EntityStateDelta>,
     client_updates_tx: Sender<EntityStateEntry>,
     game_actions_tx: Sender<GameAction>,
+    stats: Arc<ClusterStats>,
 ) {
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("tokio runtime");
-        rt.block_on(ws_loop(port, state_rx, client_updates_tx, game_actions_tx));
+        rt.block_on(ws_loop(
+            port,
+            state_rx,
+            client_updates_tx,
+            game_actions_tx,
+            stats,
+        ));
     });
 }
 
@@ -129,6 +140,7 @@ async fn ws_loop(
     state_rx: Receiver<EntityStateDelta>,
     client_updates_tx: Sender<EntityStateEntry>,
     game_actions_tx: Sender<GameAction>,
+    stats: Arc<ClusterStats>,
 ) {
     let (broadcast_tx, _) = tokio::sync::broadcast::channel::<String>(256);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -158,14 +170,19 @@ async fn ws_loop(
         }
     });
 
-    while let Ok((stream, _)) = listener.accept().await {
+    while let Ok((stream, peer_addr)) = listener.accept().await {
         let mut ws_stream = match tokio_tungstenite::accept_async(stream).await {
             Ok(s) => s,
             Err(_) => continue,
         };
+        let accept_n = stats.ws_accepts.fetch_add(1, Ordering::Relaxed) + 1;
+        if accept_n <= 3 || accept_n.is_power_of_two() {
+            eprintln!("ws accept #{} from {}", accept_n, peer_addr);
+        }
         let mut recv = broadcast_tx.subscribe();
         let updates_tx = client_updates_tx.clone();
         let actions_tx = game_actions_tx.clone();
+        let stats = stats.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -188,14 +205,19 @@ async fn ws_loop(
                     msg = ws_stream.next() => {
                         match msg {
                             Some(Ok(Message::Text(text))) => {
+                                stats.bytes_in.fetch_add(text.len() as u64, Ordering::Relaxed);
                                 match parse_client_message(&text) {
                                     Some(ClientMessage::PlayerState(entry)) => {
+                                        stats.msgs_player_state.fetch_add(1, Ordering::Relaxed);
                                         let _ = updates_tx.send(entry);
                                     }
                                     Some(ClientMessage::Action(action)) => {
+                                        stats.msgs_game_action.fetch_add(1, Ordering::Relaxed);
                                         let _ = actions_tx.send(action);
                                     }
-                                    None => {}
+                                    None => {
+                                        stats.parse_failures.fetch_add(1, Ordering::Relaxed);
+                                    }
                                 }
                             }
                             Some(Err(_)) | None => break,


### PR DESCRIPTION
## Summary

Cluster runs now expose a `/stats` HTTP endpoint and log extended counters so the benchmark harness can verify the server actually processed traffic. Silent "successful" runs (cluster seeing `entities=0` while the swarm claims hundreds of thousands of calls) are now trivially detectable.

## What's new

- **`arcane-infra::cluster_stats`** — `ClusterStats` holds atomic counters:
  - `ws_accepts`
  - `msgs_player_state`, `msgs_game_action`, `parse_failures`
  - `bytes_in`
  - `entities_current`, `entities_peak`
  - `tick`, `seq`, `last_tick_us`
- **`serve_stats_http`** — hand-rolled tiny HTTP server (no new axum dep in the `cluster-ws` feature). Binds on `CLUSTER_STATS_PORT` (default `CLUSTER_WS_PORT + 1`). `GET /stats` returns JSON.
- **`ws_server`** — increments counters on accept / parse / bytes; logs the first few accept peer addresses.
- **`cluster_runner`** — updates `entities / tick / seq / last_tick_us` atomics every tick. Extends the `ArcaneServerStats` log line with `ws_accepts / msgs_ps / msgs_ga / parse_fail / bytes_in` so log-only analysis still surfaces silent failures.

## Example

With a cluster running on port 8090, stats are reachable at `http://<host>:8091/stats`:

```json
{"cluster_id":"…","ws_accepts":0,"msgs_player_state":0,"msgs_game_action":0,
 "parse_failures":0,"bytes_in":0,"entities_current":0,"entities_peak":0,
 "tick":125,"seq":125,"last_tick_us":480}
```

If the harness sees `ws_accepts=0` or `msgs_player_state=0` after issuing work, the run is known-invalid. That's exactly the check that would have flagged yesterday's AwsArcanePerHost run.

## Scope boundary

This PR stops at the cluster side. The benchmark-repo PR that consumes `/stats` (pre-flight 1-player smoke, post-tier evidence cross-check, `run_valid` in manifest) lands separately and bumps this submodule.

## Test plan

- [x] `cargo test -p arcane-infra --features cluster-ws` green (18 existing + 2 new `cluster_stats::tests`).
- [x] `cargo clippy --features cluster-ws --tests -- -D warnings` clean.
- [ ] End-to-end: benchmark-repo PR follows, then a fresh AwsArcanePerHost run demonstrates `entities_current` matches swarm player count and `parse_failures == 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)