### PR TITLE
Shape B: per-entity pre-serialize in cluster WS; drop JSON entirely

### DIFF
--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -1,20 +1,34 @@
 //! WebSocket server for cluster state broadcast. Built only with feature "cluster-ws".
 //! Accepts incoming PLAYER_STATE messages from clients and forwards them to the tick loop.
 //!
-//! **Buckets:** inbound JSON may set **spine** (`position`, `velocity`) and **bucket 2**
+//! **Buckets:** inbound binary frames may set **spine** (`position`, `velocity`) and **bucket 2**
 //! ([`EntityStateEntry::user_data`](arcane_core::replication_channel::EntityStateEntry::user_data)).
 //! **Bucket 3** ([`local_data`](arcane_core::replication_channel::EntityStateEntry::local_data)) is
 //! never taken from the client; it stays default until the cluster sets it server-side.
 //!
-//! ## Dual wire formats
+//! ## Wire format
 //!
-//! Clients may talk JSON (legacy text) or postcard-encoded binary (via
-//! [`arcane_wire`]). Inbound parse is chosen by frame type ([`Message::Text`] vs
-//! [`Message::Binary`]); outbound encoding mirrors whatever the client sent
-//! last. A client that never sends anything gets JSON by default. This lets
-//! existing JSON clients (e.g., UE5 adapter in its current state) keep
-//! working unchanged while the benchmark swarm driver moves to binary for
-//! fairness with SpacetimeDB's BSATN default.
+//! All client/server framing is **postcard binary** via the [`arcane_wire`]
+//! crate. JSON was supported historically but has been removed — the cluster
+//! speaks one wire format end-to-end, which makes broadcast fan-out cheap
+//! (pre-encode once at the producer, share bytes via Arc across subscribers)
+//! and eliminates the per-subscriber JSON serialization cost that regressed
+//! the cluster's scaling ceiling prior to this rewrite. Non-binary Arcane
+//! clients must move to the wire protocol; see the UE5 adapter repo for the
+//! client-side migration.
+//!
+//! ## Broadcast fan-out — Shape B
+//!
+//! Each tick the producer serializes every entity **once** to a postcard byte
+//! chunk, builds a [`PreEncodedTick`] holding `Arc<Vec<u8>>` chunks plus the
+//! delta header and removed-id list, and broadcasts that to all subscribers.
+//! Per-client tasks assemble their outbound frame by selecting which entity
+//! chunks to include (today: all; with AOI: a filtered subset) and calling
+//! [`arcane_wire::encode_server_delta_from_chunks`]. Subscribers never
+//! re-serialize individual entities, so the per-tick cost is O(entity count)
+//! at the producer and O(entity count × subscriber count) in Arc clones and
+//! byte-concatenation — never O(entity count × subscriber count) in
+//! serialization, which was the regression this design fixes.
 
 use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
@@ -25,8 +39,8 @@ use arcane_core::cluster_simulation::GameAction;
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use arcane_core::Vec3;
 use arcane_wire::{
-    ClientFrame, DeltaPayload, EntityState as WireEntityState, GameActionPayload,
-    PlayerStatePayload, ServerFrame, Vec3 as WireVec3,
+    ClientFrame, DeltaHeader, EntityState as WireEntityState, GameActionPayload,
+    PlayerStatePayload, Vec3 as WireVec3,
 };
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use tokio::net::TcpListener;
@@ -35,91 +49,10 @@ use uuid::Uuid;
 
 use crate::cluster_stats::ClusterStats;
 
-/// Incoming message from a client. Expects JSON:
-/// `{"type":"PLAYER_STATE","entity_id":"uuid","position":{...},"velocity":{...},"user_data":?}`.
-/// Optional **`user_data`** is **bucket 2** (replicated simulation JSON). Unknown keys are ignored.
-#[derive(serde::Deserialize)]
-struct PlayerStateMessage {
-    #[serde(rename = "type")]
-    msg_type: String,
-    entity_id: String,
-    position: Vec3Message,
-    velocity: Vec3Message,
-    #[serde(default)]
-    user_data: serde_json::Value,
-}
-
-#[derive(serde::Deserialize)]
-struct Vec3Message {
-    x: f64,
-    y: f64,
-    z: f64,
-}
-
-/// Maximum byte length of the raw WebSocket text payload accepted from a client.
+/// Maximum byte length of a single inbound WebSocket binary payload. Client
+/// frames larger than this are dropped and counted as parse failures —
+/// defends against runaway allocations from misbehaving clients.
 const MAX_MESSAGE_BYTES: usize = 64 * 1024; // 64 KiB
-
-fn is_finite_vec3(v: &Vec3Message) -> bool {
-    v.x.is_finite() && v.y.is_finite() && v.z.is_finite()
-}
-
-fn parse_player_state(text: &str) -> Option<EntityStateEntry> {
-    if text.len() > MAX_MESSAGE_BYTES {
-        return None;
-    }
-    let msg: PlayerStateMessage = serde_json::from_str(text).ok()?;
-    if msg.msg_type != "PLAYER_STATE" {
-        return None;
-    }
-    if !is_finite_vec3(&msg.position) || !is_finite_vec3(&msg.velocity) {
-        return None;
-    }
-    let entity_id = Uuid::parse_str(&msg.entity_id).ok()?;
-    // cluster_id set by cluster binary when applying (this connection is to that cluster)
-    let mut entry = EntityStateEntry::new(
-        entity_id,
-        Uuid::nil(),
-        Vec3::new(msg.position.x, msg.position.y, msg.position.z),
-        Vec3::new(msg.velocity.x, msg.velocity.y, msg.velocity.z),
-    );
-    entry.user_data = msg.user_data;
-    Some(entry)
-}
-
-/// Generic incoming WebSocket message — we peek at "type" to decide how to route it.
-#[derive(serde::Deserialize)]
-struct TypePeek {
-    #[serde(rename = "type")]
-    msg_type: String,
-}
-
-/// Parse a game action message. Expects JSON:
-/// `{"type":"GAME_ACTION","entity_id":"uuid","action_type":"use_item","payload":{...}}`.
-fn parse_game_action(text: &str) -> Option<GameAction> {
-    if text.len() > MAX_MESSAGE_BYTES {
-        return None;
-    }
-    serde_json::from_str::<GameAction>(text).ok()
-}
-
-/// Result of parsing an incoming WebSocket text message.
-enum ClientMessage {
-    PlayerState(EntityStateEntry),
-    Action(GameAction),
-}
-
-/// Route an incoming WebSocket text message to the appropriate type.
-fn parse_client_message(text: &str) -> Option<ClientMessage> {
-    if text.len() > MAX_MESSAGE_BYTES {
-        return None;
-    }
-    let peek: TypePeek = serde_json::from_str(text).ok()?;
-    match peek.msg_type.as_str() {
-        "PLAYER_STATE" => parse_player_state(text).map(ClientMessage::PlayerState),
-        "GAME_ACTION" => parse_game_action(text).map(ClientMessage::Action),
-        _ => None,
-    }
-}
 
 fn should_keep_ws_loop_running_on_broadcast_error(
     error: &tokio::sync::broadcast::error::RecvError,
@@ -171,33 +104,70 @@ fn game_action_from_wire(payload: &GameActionPayload) -> Option<GameAction> {
     })
 }
 
-/// Convert the cluster-internal [`EntityStateDelta`] into the wire-level
-/// [`DeltaPayload`]. Shapes match 1:1; `user_data` `Value`s are encoded to
-/// JSON bytes (the opaque-bytes contract the wire layer assumes).
-fn wire_delta_from_internal(delta: &EntityStateDelta) -> DeltaPayload {
-    DeltaPayload {
-        source_cluster_id: delta.source_cluster_id,
-        seq: delta.seq,
-        tick: delta.tick,
-        timestamp: delta.timestamp,
-        updated: delta
+/// Convert one cluster-internal [`EntityStateEntry`] to a postcard-encoded
+/// [`WireEntityState`] byte chunk. Producer calls this once per entity per
+/// tick; the resulting bytes are shared across all subscribers via
+/// [`PreEncodedTick`].
+///
+/// Errors are swallowed to an empty chunk. Postcard failures on a valid
+/// [`WireEntityState`] are essentially impossible (no variable-length fields
+/// that can fail to serialize), so this is a defensive fallback rather than
+/// a meaningful error path.
+fn encode_entity_chunk(entity: &EntityStateEntry) -> Vec<u8> {
+    let user_data_bytes = if entity.user_data.is_null() {
+        Vec::new()
+    } else {
+        // Shouldn't fail for any valid Value; log-and-drop is fine if it does.
+        serde_json::to_vec(&entity.user_data).unwrap_or_default()
+    };
+    let wire = WireEntityState {
+        entity_id: entity.entity_id,
+        cluster_id: entity.cluster_id,
+        position: WireVec3::new(entity.position.x, entity.position.y, entity.position.z),
+        velocity: WireVec3::new(entity.velocity.x, entity.velocity.y, entity.velocity.z),
+        user_data: user_data_bytes,
+    };
+    arcane_wire::encode_entity_state(&wire).unwrap_or_default()
+}
+
+/// Per-tick snapshot assembled once by the producer and broadcast to all
+/// subscribers. Each per-client task builds its outbound wire frame by
+/// selecting which entity chunks it wants (today: all; with AOI: a subset)
+/// and calling [`arcane_wire::encode_server_delta_from_chunks`].
+///
+/// Entity chunks are `Arc<Vec<u8>>` so N subscribers share one allocation per
+/// entity per tick — the whole point of this struct and of Shape B.
+struct PreEncodedTick {
+    header: DeltaHeader,
+    entity_chunks: Vec<Arc<Vec<u8>>>,
+    removed: Vec<Uuid>,
+}
+
+/// Convert an [`EntityStateDelta`] to a [`PreEncodedTick`] by serializing
+/// each entity once. Called by the producer task every tick.
+fn pre_encode_tick(delta: &EntityStateDelta) -> PreEncodedTick {
+    PreEncodedTick {
+        header: DeltaHeader {
+            source_cluster_id: delta.source_cluster_id,
+            seq: delta.seq,
+            tick: delta.tick,
+            timestamp: delta.timestamp,
+        },
+        entity_chunks: delta
             .updated
             .iter()
-            .map(|e| WireEntityState {
-                entity_id: e.entity_id,
-                cluster_id: e.cluster_id,
-                position: WireVec3::new(e.position.x, e.position.y, e.position.z),
-                velocity: WireVec3::new(e.velocity.x, e.velocity.y, e.velocity.z),
-                user_data: if e.user_data.is_null() {
-                    Vec::new()
-                } else {
-                    // Shouldn't fail for any valid Value; log-and-drop is fine if it does.
-                    serde_json::to_vec(&e.user_data).unwrap_or_default()
-                },
-            })
+            .map(|e| Arc::new(encode_entity_chunk(e)))
             .collect(),
         removed: delta.removed.clone(),
     }
+}
+
+/// Assemble the outbound wire frame for one subscriber from a shared
+/// [`PreEncodedTick`]. Today every subscriber takes all chunks; with AOI it
+/// will take a filtered subset.
+fn assemble_outbound_frame(tick: &PreEncodedTick) -> Result<Vec<u8>, arcane_wire::Error> {
+    let chunk_refs: Vec<&[u8]> = tick.entity_chunks.iter().map(|c| c.as_slice()).collect();
+    arcane_wire::encode_server_delta_from_chunks(&tick.header, &chunk_refs, &tick.removed)
 }
 
 /// Route a binary client frame to the cluster-internal message channel.
@@ -276,15 +246,15 @@ async fn ws_loop(
     game_actions_tx: Sender<GameAction>,
     stats: Arc<ClusterStats>,
 ) {
-    // Broadcast carries the raw internal delta. Each subscriber encodes in
-    // its own preferred format on send. Keeping the channel codec-agnostic
-    // means adding a third format later (flatbuffers, CBOR, whatever) only
-    // touches per-client encode, not the producer.
-    let (broadcast_tx, _) = tokio::sync::broadcast::channel::<Arc<EntityStateDelta>>(256);
+    // Broadcast carries a PreEncodedTick — per-entity postcard chunks plus
+    // delta header and removed-id list. Subscribers assemble their outbound
+    // frame from the shared chunks via arcane_wire::encode_server_delta_from_chunks.
+    // One serialization per entity per tick, shared across all subscribers.
+    let (broadcast_tx, _) = tokio::sync::broadcast::channel::<Arc<PreEncodedTick>>(256);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await.expect("bind ws port");
     eprintln!(
-        "cluster WebSocket listening on ws://{} (send PLAYER_STATE to push player entity)",
+        "cluster WebSocket listening on ws://{} (binary arcane-wire frames only)",
         addr
     );
 
@@ -299,7 +269,11 @@ async fn ws_loop(
                 .unwrap();
             match delta {
                 Ok(d) => {
-                    let _ = tx_clone.send(Arc::new(d));
+                    // Per-tick producer work: serialize every entity once
+                    // and build the shared tick struct. All subscribers
+                    // reuse these Arc-shared chunks without re-serializing.
+                    let tick = Arc::new(pre_encode_tick(&d));
+                    let _ = tx_clone.send(tick);
                 }
                 Err(_) => break,
             }
@@ -320,29 +294,20 @@ async fn ws_loop(
         let actions_tx = game_actions_tx.clone();
         let stats = stats.clone();
         tokio::spawn(async move {
-            // Encoding preference for outbound broadcasts. Starts in text/JSON;
-            // the first binary frame we receive from this client upgrades it
-            // to postcard. This means a client that only listens (never sends)
-            // gets JSON — the conservative default for existing UE5 clients.
-            let mut prefer_binary = false;
             loop {
                 tokio::select! {
                     result = recv.recv() => {
                         match result {
-                            Ok(delta_arc) => {
-                                let send_result = if prefer_binary {
-                                    let wire = wire_delta_from_internal(&delta_arc);
-                                    match arcane_wire::encode_server(&ServerFrame::Delta(wire)) {
-                                        Ok(bytes) => ws_stream.send(Message::Binary(bytes)).await,
-                                        Err(_) => continue,
-                                    }
-                                } else {
-                                    match serde_json::to_string(&*delta_arc) {
-                                        Ok(json) => ws_stream.send(Message::Text(json)).await,
-                                        Err(_) => continue,
-                                    }
+                            Ok(tick_arc) => {
+                                // Subscriber-side work: pick entity chunks
+                                // (today: all; with AOI: filtered subset)
+                                // and assemble a wire-compatible frame. No
+                                // per-entity re-serialization happens here.
+                                let bytes = match assemble_outbound_frame(&tick_arc) {
+                                    Ok(b) => b,
+                                    Err(_) => continue,
                                 };
-                                if send_result.is_err() {
+                                if ws_stream.send(Message::Binary(bytes)).await.is_err() {
                                     break;
                                 }
                             }
@@ -357,29 +322,12 @@ async fn ws_loop(
                     }
                     msg = ws_stream.next() => {
                         match msg {
-                            Some(Ok(Message::Text(text))) => {
-                                stats.bytes_in.fetch_add(text.len() as u64, Ordering::Relaxed);
-                                match parse_client_message(&text) {
-                                    Some(ClientMessage::PlayerState(entry)) => {
-                                        stats.msgs_player_state.fetch_add(1, Ordering::Relaxed);
-                                        stats.note_entity_id(entry.entity_id);
-                                        let _ = updates_tx.send(entry);
-                                    }
-                                    Some(ClientMessage::Action(action)) => {
-                                        stats.msgs_game_action.fetch_add(1, Ordering::Relaxed);
-                                        stats.note_entity_id(action.entity_id);
-                                        let _ = actions_tx.send(action);
-                                    }
-                                    None => {
-                                        stats.parse_failures.fetch_add(1, Ordering::Relaxed);
-                                    }
-                                }
-                            }
                             Some(Ok(Message::Binary(bytes))) => {
-                                prefer_binary = true;
                                 let _ = handle_binary_client_frame(&bytes, &updates_tx, &actions_tx, &stats);
                             }
                             Some(Err(_)) | None => break,
+                            // Text and other frame types are not part of the
+                            // supported wire protocol and are silently ignored.
                             _ => {}
                         }
                     }
@@ -392,9 +340,8 @@ async fn ws_loop(
 #[cfg(test)]
 mod tests {
     use super::{
-        entry_from_wire_player_state, game_action_from_wire, parse_client_message,
-        parse_game_action, parse_player_state, should_keep_ws_loop_running_on_broadcast_error,
-        wire_delta_from_internal, ClientMessage,
+        assemble_outbound_frame, encode_entity_chunk, entry_from_wire_player_state,
+        game_action_from_wire, pre_encode_tick, should_keep_ws_loop_running_on_broadcast_error,
     };
     use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
     use arcane_core::Vec3;
@@ -404,139 +351,7 @@ mod tests {
     use tokio::sync::broadcast::error::RecvError;
     use uuid::Uuid;
 
-    #[test]
-    fn parse_player_state_accepts_valid_payload() {
-        let id = Uuid::from_u128(1);
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":1.0,"y":2.0,"z":3.0}},"velocity":{{"x":0.1,"y":0.2,"z":0.3}}}}"#,
-            id
-        );
-        let parsed = parse_player_state(&payload).expect("valid payload should parse");
-        assert_eq!(parsed.entity_id, id);
-        assert_eq!(parsed.position.x, 1.0);
-        assert_eq!(parsed.velocity.z, 0.3);
-        assert!(parsed.user_data.is_null());
-    }
-
-    #[test]
-    fn parse_player_state_rejects_non_player_state_messages() {
-        let payload = r#"{"type":"PING","entity_id":"00000000-0000-0000-0000-000000000000","position":{"x":0.0,"y":0.0,"z":0.0},"velocity":{"x":0.0,"y":0.0,"z":0.0}}"#;
-        assert!(parse_player_state(payload).is_none());
-    }
-
-    #[test]
-    fn parse_player_state_accepts_optional_user_data() {
-        let id = Uuid::from_u128(2);
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":0.0,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}},"user_data":{{"stamina":99}}}}"#,
-            id
-        );
-        let parsed = parse_player_state(&payload).expect("parse");
-        assert_eq!(parsed.user_data, serde_json::json!({"stamina": 99}));
-        assert!(parsed.local_data.is_null());
-    }
-
-    #[test]
-    fn parse_player_state_rejects_nan_position() {
-        let id = Uuid::from_u128(3);
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":null,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}}}}"#,
-            id
-        );
-        // NaN comes through as null in JSON which fails f64 deser, so test with Infinity
-        assert!(parse_player_state(&payload).is_none());
-    }
-
-    #[test]
-    fn parse_player_state_rejects_infinity_velocity() {
-        let id = Uuid::from_u128(4);
-        // serde_json rejects bare Infinity, so craft a message that parses but has inf
-        // Actually serde_json does not produce f64::INFINITY from JSON — JSON has no Infinity literal.
-        // But we can test our guard by injecting via a known-finite but very large value.
-        // The real protection: is_finite_vec3 rejects NaN/Inf if they ever appear in the struct.
-        // Test the helper directly:
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":1e300,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}}}}"#,
-            id
-        );
-        // 1e300 is finite, so this should parse
-        assert!(parse_player_state(&payload).is_some());
-    }
-
-    #[test]
-    fn parse_player_state_rejects_missing_position() {
-        let id = Uuid::from_u128(5);
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","velocity":{{"x":0.0,"y":0.0,"z":0.0}}}}"#,
-            id
-        );
-        assert!(parse_player_state(&payload).is_none());
-    }
-
-    #[test]
-    fn parse_player_state_rejects_invalid_uuid() {
-        let payload = r#"{"type":"PLAYER_STATE","entity_id":"not-a-uuid","position":{"x":0.0,"y":0.0,"z":0.0},"velocity":{"x":0.0,"y":0.0,"z":0.0}}"#;
-        assert!(parse_player_state(payload).is_none());
-    }
-
-    #[test]
-    fn parse_player_state_rejects_oversized_payload() {
-        let id = Uuid::from_u128(6);
-        let big_data = "x".repeat(70_000);
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":0.0,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}},"user_data":{{"data":"{}"}}}}"#,
-            id, big_data
-        );
-        assert!(parse_player_state(&payload).is_none());
-    }
-
-    #[test]
-    fn parse_game_action_accepts_valid_payload() {
-        let id = Uuid::from_u128(10);
-        let payload = format!(
-            r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"use_item","payload":{{"item_type":5}}}}"#,
-            id
-        );
-        let action = parse_game_action(&payload).expect("valid game action");
-        assert_eq!(action.entity_id, id);
-        assert_eq!(action.action_type, "use_item");
-        assert_eq!(action.payload, serde_json::json!({"item_type": 5}));
-    }
-
-    #[test]
-    fn parse_client_message_routes_player_state() {
-        let id = Uuid::from_u128(1);
-        let payload = format!(
-            r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":1.0,"y":0.0,"z":0.0}},"velocity":{{"x":0.0,"y":0.0,"z":0.0}}}}"#,
-            id
-        );
-        match parse_client_message(&payload) {
-            Some(ClientMessage::PlayerState(e)) => assert_eq!(e.entity_id, id),
-            _ => panic!("expected PlayerState"),
-        }
-    }
-
-    #[test]
-    fn parse_client_message_routes_game_action() {
-        let id = Uuid::from_u128(20);
-        let payload = format!(
-            r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"cast_spell","payload":{{}}}}"#,
-            id
-        );
-        match parse_client_message(&payload) {
-            Some(ClientMessage::Action(a)) => {
-                assert_eq!(a.entity_id, id);
-                assert_eq!(a.action_type, "cast_spell");
-            }
-            _ => panic!("expected Action"),
-        }
-    }
-
-    #[test]
-    fn parse_client_message_rejects_unknown_type() {
-        let payload = r#"{"type":"UNKNOWN","data":"foo"}"#;
-        assert!(parse_client_message(payload).is_none());
-    }
+    // ── backpressure policy ──────────────────────────────────────────────
 
     #[test]
     fn backpressure_policy_keeps_loop_on_lagged_messages() {
@@ -551,6 +366,8 @@ mod tests {
             &RecvError::Closed
         ));
     }
+
+    // ── inbound wire decode (kept from the pre-Shape-B era) ──────────────
 
     #[test]
     fn entry_from_wire_rejects_non_finite_position() {
@@ -603,56 +420,6 @@ mod tests {
     }
 
     #[test]
-    fn wire_delta_preserves_shape_and_user_data_bytes() {
-        let eid = Uuid::from_u128(7);
-        let cid = Uuid::from_u128(9);
-        let mut entry =
-            EntityStateEntry::new(eid, cid, Vec3::new(1.0, 2.0, 3.0), Vec3::new(0.1, 0.2, 0.3));
-        entry.user_data = serde_json::json!({"stamina": 42});
-
-        let delta = EntityStateDelta {
-            source_cluster_id: cid,
-            seq: 5,
-            tick: 100,
-            timestamp: 1.5,
-            updated: vec![entry],
-            removed: vec![Uuid::from_u128(11)],
-        };
-
-        let wire = wire_delta_from_internal(&delta);
-        assert_eq!(wire.seq, 5);
-        assert_eq!(wire.tick, 100);
-        assert_eq!(wire.updated.len(), 1);
-        assert_eq!(wire.updated[0].entity_id, eid);
-        assert_eq!(wire.updated[0].position.x, 1.0);
-        let recovered: serde_json::Value =
-            serde_json::from_slice(&wire.updated[0].user_data).unwrap();
-        assert_eq!(recovered, serde_json::json!({"stamina": 42}));
-        assert_eq!(wire.removed, vec![Uuid::from_u128(11)]);
-    }
-
-    #[test]
-    fn wire_delta_emits_empty_user_data_bytes_for_null_value() {
-        let entry = EntityStateEntry::new(
-            Uuid::from_u128(1),
-            Uuid::nil(),
-            Vec3::new(0.0, 0.0, 0.0),
-            Vec3::new(0.0, 0.0, 0.0),
-        );
-        // user_data stays default (Null) via EntityStateEntry::new
-        let delta = EntityStateDelta {
-            source_cluster_id: Uuid::nil(),
-            seq: 0,
-            tick: 0,
-            timestamp: 0.0,
-            updated: vec![entry],
-            removed: Vec::new(),
-        };
-        let wire = wire_delta_from_internal(&delta);
-        assert!(wire.updated[0].user_data.is_empty());
-    }
-
-    #[test]
     fn binary_client_frame_roundtrips_player_state_through_arcane_wire() {
         // End-to-end: wire-encode a ClientFrame::PlayerState, decode via
         // arcane_wire::decode_client, convert via entry_from_wire_player_state.
@@ -674,26 +441,187 @@ mod tests {
         assert_eq!(entry.velocity.z, -0.1);
     }
 
+    // ── Shape B primitives: encode_entity_chunk + pre_encode_tick +
+    //    assemble_outbound_frame ─────────────────────────────────────────
+
+    /// A chunk produced by `encode_entity_chunk` must be a valid standalone
+    /// postcard encoding of a `WireEntityState` — i.e. decode round-trip
+    /// succeeds through `arcane_wire`'s primitives.
     #[test]
-    fn binary_server_frame_roundtrips_delta_through_arcane_wire() {
+    fn encode_entity_chunk_produces_decodable_wire_entity_state() {
+        let mut entry = EntityStateEntry::new(
+            Uuid::from_u128(7),
+            Uuid::from_u128(9),
+            Vec3::new(1.0, 2.0, 3.0),
+            Vec3::new(0.1, 0.2, 0.3),
+        );
+        entry.user_data = serde_json::json!({"hp": 99});
+        let chunk = encode_entity_chunk(&entry);
+
+        let wire = arcane_wire::decode_entity_state(&chunk).expect("chunk decodes");
+        assert_eq!(wire.entity_id, entry.entity_id);
+        assert_eq!(wire.cluster_id, entry.cluster_id);
+        assert_eq!(wire.position.x, 1.0);
+        assert_eq!(wire.velocity.z, 0.3);
+        let recovered: serde_json::Value = serde_json::from_slice(&wire.user_data).unwrap();
+        assert_eq!(recovered, serde_json::json!({"hp": 99}));
+    }
+
+    #[test]
+    fn encode_entity_chunk_emits_empty_user_data_for_null_value() {
         let entry = EntityStateEntry::new(
             Uuid::from_u128(1),
             Uuid::nil(),
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
+        );
+        let chunk = encode_entity_chunk(&entry);
+        let wire = arcane_wire::decode_entity_state(&chunk).unwrap();
+        assert!(wire.user_data.is_empty());
+    }
+
+    /// Producer path end-to-end: build a delta, pre-encode it into chunks,
+    /// assemble the outbound frame, decode via the standard
+    /// `arcane_wire::decode_server`, and verify shape + content. This
+    /// exercises the same flow the ws_loop follows every tick.
+    #[test]
+    fn pre_encode_and_assemble_roundtrip_matches_input_delta() {
+        let mut entry_a = EntityStateEntry::new(
+            Uuid::from_u128(1),
+            Uuid::from_u128(99),
             Vec3::new(1.0, 2.0, 3.0),
             Vec3::new(0.0, 0.0, 0.0),
         );
+        entry_a.user_data = serde_json::json!({"hp": 42});
+        let entry_b = EntityStateEntry::new(
+            Uuid::from_u128(2),
+            Uuid::from_u128(99),
+            Vec3::new(10.0, 20.0, 30.0),
+            Vec3::new(0.5, 0.0, 0.0),
+        );
+
+        let delta = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(99),
+            seq: 7,
+            tick: 42,
+            timestamp: 1.5,
+            updated: vec![entry_a.clone(), entry_b.clone()],
+            removed: vec![Uuid::from_u128(5)],
+        };
+
+        let pre_tick = pre_encode_tick(&delta);
+        assert_eq!(pre_tick.entity_chunks.len(), 2);
+        assert_eq!(pre_tick.removed, vec![Uuid::from_u128(5)]);
+        assert_eq!(pre_tick.header.seq, 7);
+        assert_eq!(pre_tick.header.tick, 42);
+
+        let bytes = assemble_outbound_frame(&pre_tick).expect("assemble");
+        let decoded = arcane_wire::decode_server(&bytes).expect("decode");
+        let ServerFrame::Delta(payload) = decoded;
+
+        assert_eq!(payload.source_cluster_id, delta.source_cluster_id);
+        assert_eq!(payload.seq, 7);
+        assert_eq!(payload.tick, 42);
+        assert_eq!(payload.timestamp, 1.5);
+        assert_eq!(payload.updated.len(), 2);
+        assert_eq!(payload.updated[0].entity_id, entry_a.entity_id);
+        assert_eq!(payload.updated[1].entity_id, entry_b.entity_id);
+        assert_eq!(payload.removed, vec![Uuid::from_u128(5)]);
+
+        // user_data bytes round-trip correctly for the entity that had one.
+        let recovered: serde_json::Value =
+            serde_json::from_slice(&payload.updated[0].user_data).unwrap();
+        assert_eq!(recovered, serde_json::json!({"hp": 42}));
+        assert!(payload.updated[1].user_data.is_empty());
+    }
+
+    /// Empty delta (no entities, no removals) is still a valid encoded frame.
+    #[test]
+    fn pre_encode_and_assemble_handles_empty_delta() {
         let delta = EntityStateDelta {
             source_cluster_id: Uuid::nil(),
+            seq: 0,
+            tick: 0,
+            timestamp: 0.0,
+            updated: Vec::new(),
+            removed: Vec::new(),
+        };
+        let pre_tick = pre_encode_tick(&delta);
+        let bytes = assemble_outbound_frame(&pre_tick).expect("assemble");
+        let decoded = arcane_wire::decode_server(&bytes).expect("decode");
+        let ServerFrame::Delta(payload) = decoded;
+        assert!(payload.updated.is_empty());
+        assert!(payload.removed.is_empty());
+    }
+
+    /// **The Shape B correctness guarantee:** subscribers produce the same
+    /// bytes they would have produced if we'd re-serialized the whole delta
+    /// per subscriber (the pre-regression code path's output shape), but now
+    /// the per-entity serialization happens once and is reused. Verifies
+    /// bit-for-bit parity between the pre-encoded-chunks path and a
+    /// reference `arcane_wire::encode_server(ServerFrame::Delta(...))`
+    /// invocation on the equivalent payload.
+    #[test]
+    fn shape_b_outbound_bytes_match_full_encode_byte_for_byte() {
+        let mut entities = Vec::new();
+        for i in 0..50_u128 {
+            let mut e = EntityStateEntry::new(
+                Uuid::from_u128(i),
+                Uuid::from_u128(99),
+                Vec3::new(i as f64, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            );
+            if i % 2 == 0 {
+                e.user_data = serde_json::json!({"idx": i as u64});
+            }
+            entities.push(e);
+        }
+        let delta = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(99),
             seq: 1,
             tick: 2,
             timestamp: 3.0,
-            updated: vec![entry],
-            removed: Vec::new(),
+            updated: entities.clone(),
+            removed: vec![Uuid::from_u128(999), Uuid::from_u128(1000)],
         };
-        let wire = wire_delta_from_internal(&delta);
-        let bytes = arcane_wire::encode_server(&ServerFrame::Delta(wire.clone())).unwrap();
-        let decoded = arcane_wire::decode_server(&bytes).unwrap();
-        let ServerFrame::Delta(decoded_wire) = decoded;
-        assert_eq!(decoded_wire, wire);
+
+        let via_shape_b =
+            assemble_outbound_frame(&pre_encode_tick(&delta)).expect("shape-b bytes");
+
+        // Reference: build the wire DeltaPayload by materializing every
+        // WireEntityState inline, encode as one ServerFrame::Delta — the
+        // pre-regression path's output shape.
+        let wire_updated: Vec<arcane_wire::EntityState> = entities
+            .iter()
+            .map(|e| {
+                let user_data = if e.user_data.is_null() {
+                    Vec::new()
+                } else {
+                    serde_json::to_vec(&e.user_data).unwrap()
+                };
+                arcane_wire::EntityState {
+                    entity_id: e.entity_id,
+                    cluster_id: e.cluster_id,
+                    position: WireVec3::new(e.position.x, e.position.y, e.position.z),
+                    velocity: WireVec3::new(e.velocity.x, e.velocity.y, e.velocity.z),
+                    user_data,
+                }
+            })
+            .collect();
+        let reference_payload = arcane_wire::DeltaPayload {
+            source_cluster_id: delta.source_cluster_id,
+            seq: delta.seq,
+            tick: delta.tick,
+            timestamp: delta.timestamp,
+            updated: wire_updated,
+            removed: delta.removed.clone(),
+        };
+        let via_reference =
+            arcane_wire::encode_server(&ServerFrame::Delta(reference_payload)).expect("ref bytes");
+
+        assert_eq!(
+            via_shape_b, via_reference,
+            "Shape B must produce bit-identical output to the full-encode path"
+        );
     }
 }

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -585,8 +585,7 @@ mod tests {
             removed: vec![Uuid::from_u128(999), Uuid::from_u128(1000)],
         };
 
-        let via_shape_b =
-            assemble_outbound_frame(&pre_encode_tick(&delta)).expect("shape-b bytes");
+        let via_shape_b = assemble_outbound_frame(&pre_encode_tick(&delta)).expect("shape-b bytes");
 
         // Reference: build the wire DeltaPayload by materializing every
         // WireEntityState inline, encode as one ServerFrame::Delta — the

--- a/crates/arcane-wire/src/lib.rs
+++ b/crates/arcane-wire/src/lib.rs
@@ -524,8 +524,7 @@ mod tests {
         // Producer pre-encodes all three entities once. Subscriber takes only
         // the first and third — the AOI filter result.
         let via_chunks =
-            encode_server_delta_from_chunks(&header, &[c1.as_slice(), c3.as_slice()], &[])
-                .unwrap();
+            encode_server_delta_from_chunks(&header, &[c1.as_slice(), c3.as_slice()], &[]).unwrap();
 
         let decoded = decode_server(&via_chunks).unwrap();
         let ServerFrame::Delta(payload) = decoded;

--- a/crates/arcane-wire/src/lib.rs
+++ b/crates/arcane-wire/src/lib.rs
@@ -141,6 +141,124 @@ pub fn decode_server(bytes: &[u8]) -> Result<ServerFrame, postcard::Error> {
     postcard::from_bytes(bytes)
 }
 
+/// Re-exported codec error type. Callers import this instead of `postcard::Error`
+/// so they don't depend on the codec choice directly — swapping codecs later
+/// changes only this crate's internals.
+pub type Error = postcard::Error;
+
+/// Encode a single [`EntityState`] as standalone postcard bytes. The intended
+/// caller is the cluster's WS server, which pre-encodes each entity once per
+/// tick and then shares the bytes across all subscribers via
+/// [`encode_server_delta_from_chunks`]. Matches the per-entity byte layout
+/// that would otherwise appear inside a full `ServerFrame::Delta` encoding.
+pub fn encode_entity_state(entity: &EntityState) -> Result<Vec<u8>, Error> {
+    postcard::to_allocvec(entity)
+}
+
+/// Decode standalone postcard bytes back to an [`EntityState`]. Mostly useful
+/// in tests that validate the chunk-assembly primitives.
+pub fn decode_entity_state(bytes: &[u8]) -> Result<EntityState, Error> {
+    postcard::from_bytes(bytes)
+}
+
+/// Header fields for a [`DeltaPayload`] — everything except the `updated` and
+/// `removed` lists. Used with [`encode_server_delta_from_chunks`] to assemble
+/// a wire frame from pre-encoded per-entity bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeltaHeader {
+    pub source_cluster_id: Uuid,
+    pub seq: i64,
+    pub tick: u64,
+    pub timestamp: f64,
+}
+
+/// Assemble a postcard-encoded `ServerFrame::Delta` from a header, a list of
+/// already-postcard-encoded [`EntityState`] byte chunks, and a list of removed
+/// entity ids.
+///
+/// This is the broadcast-fan-out primitive the cluster server uses to
+/// serialize each entity **once** per tick (at the producer) and then build
+/// per-subscriber frames by **concatenating** the cached chunks — rather than
+/// re-serializing the full delta N times, once per subscriber, which is the
+/// O(N) cost pattern this primitive exists to avoid. It is also the hook for
+/// AOI (area-of-interest) filtering: when a subscriber only wants a subset of
+/// entities, pass only that subset's chunks; no re-serialization is needed.
+///
+/// ## Wire compatibility
+///
+/// The output is bit-for-bit identical to what
+/// `encode_server(&ServerFrame::Delta(DeltaPayload { ... }))` would produce
+/// for the equivalent fully-materialized payload. Existing clients decode the
+/// output via the standard [`decode_server`]; they do not know (and do not
+/// need to know) that the frame was assembled from chunks on the server side.
+///
+/// ## Input contract
+///
+/// Each byte slice in `entity_chunks` must be a valid postcard encoding of an
+/// [`EntityState`] — typically produced by `postcard::to_allocvec(&entity)`
+/// (or the equivalent on a `&EntityState`). Passing malformed bytes here
+/// produces a malformed frame that downstream decoders will reject; this
+/// function does not validate the chunks.
+pub fn encode_server_delta_from_chunks(
+    header: &DeltaHeader,
+    entity_chunks: &[&[u8]],
+    removed: &[Uuid],
+) -> Result<Vec<u8>, postcard::Error> {
+    // Strategy: serialize a scaffold `ServerFrame::Delta(DeltaPayload { ... })`
+    // with empty `updated` and empty `removed`. The scaffold's last two bytes
+    // are the postcard varints for those two empty-list lengths (each encodes
+    // to a single 0 byte). We then replace that tail with (a) the varint for
+    // our real updated count + the concatenated entity chunks, and (b) the
+    // varint for our real removed count + the 16-byte UUID bytes for each
+    // removed id.
+    //
+    // This avoids hand-rolling postcard's varint or enum-variant encoding —
+    // we let postcard produce the header bytes for us, then splice in the two
+    // list bodies.
+    let scaffold_payload = DeltaPayload {
+        source_cluster_id: header.source_cluster_id,
+        seq: header.seq,
+        tick: header.tick,
+        timestamp: header.timestamp,
+        updated: Vec::new(),
+        removed: Vec::new(),
+    };
+    let scaffold = postcard::to_allocvec(&ServerFrame::Delta(scaffold_payload))?;
+
+    // The scaffold encoding ends with two 0-byte varints (the two empty-list
+    // lengths). Everything before them is the variant tag + fixed-width and
+    // variable-width header fields we want verbatim.
+    let header_len = scaffold
+        .len()
+        .checked_sub(2)
+        .expect("scaffold always has two trailing zero-length varints");
+    let mut out = Vec::with_capacity(header_len + chunks_total_len(entity_chunks) + 16);
+    out.extend_from_slice(&scaffold[..header_len]);
+
+    // Postcard's `Vec<T>` length prefix is the same varint encoding postcard
+    // uses for any sequence — including `Vec<()>`. Serializing `Vec<()>` of
+    // the right length is the cheapest way to emit exactly that varint
+    // without reaching into postcard's internal varint helpers.
+    let updated_len_prefix: Vec<u8> = postcard::to_allocvec(&vec![(); entity_chunks.len()])?;
+    out.extend_from_slice(&updated_len_prefix);
+    for chunk in entity_chunks {
+        out.extend_from_slice(chunk);
+    }
+
+    // Removed list: varint(len) + 16 bytes per Uuid. Uuid's postcard encoding
+    // is its 16 raw bytes in big-endian order. Using `postcard::to_allocvec`
+    // on the whole `Vec<Uuid>` produces exactly that layout, so we just
+    // serialize the list directly.
+    let removed_bytes: Vec<u8> = postcard::to_allocvec(&removed.to_vec())?;
+    out.extend_from_slice(&removed_bytes);
+
+    Ok(out)
+}
+
+fn chunks_total_len(chunks: &[&[u8]]) -> usize {
+    chunks.iter().map(|c| c.len()).sum()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +354,212 @@ mod tests {
         };
         let recovered: serde_json::Value = serde_json::from_slice(&payload.user_data).unwrap();
         assert_eq!(recovered, original_value);
+    }
+
+    // ── encode_server_delta_from_chunks — Shape B producer primitive ──
+
+    fn sample_header() -> DeltaHeader {
+        DeltaHeader {
+            source_cluster_id: Uuid::from_u128(0xcafe_babe_dead_beef_0000_1111_2222_3333),
+            seq: 42,
+            tick: 100,
+            timestamp: 12.5,
+        }
+    }
+
+    fn encode_entity(entity: &EntityState) -> Vec<u8> {
+        postcard::to_allocvec(entity).expect("encode entity")
+    }
+
+    /// The key correctness property: chunk-assembled output is bit-for-bit
+    /// identical to what `encode_server` produces for the equivalent fully-
+    /// materialized payload. Existing decoders must not be able to tell the
+    /// difference.
+    #[test]
+    fn chunk_assembled_frame_matches_full_encode_byte_for_byte() {
+        let e1 = sample_entity();
+        let e2 = EntityState {
+            entity_id: Uuid::from_u128(7),
+            cluster_id: Uuid::from_u128(9),
+            position: Vec3::new(0.0, 0.0, 0.0),
+            velocity: Vec3::new(0.25, -0.5, 0.75),
+            user_data: Vec::new(),
+        };
+        let removed = vec![Uuid::from_u128(0xdead), Uuid::from_u128(0xbeef)];
+
+        let header = sample_header();
+        let full_payload = DeltaPayload {
+            source_cluster_id: header.source_cluster_id,
+            seq: header.seq,
+            tick: header.tick,
+            timestamp: header.timestamp,
+            updated: vec![e1.clone(), e2.clone()],
+            removed: removed.clone(),
+        };
+        let via_full = encode_server(&ServerFrame::Delta(full_payload)).unwrap();
+
+        let chunk1 = encode_entity(&e1);
+        let chunk2 = encode_entity(&e2);
+        let via_chunks = encode_server_delta_from_chunks(
+            &header,
+            &[chunk1.as_slice(), chunk2.as_slice()],
+            &removed,
+        )
+        .unwrap();
+
+        assert_eq!(
+            via_full, via_chunks,
+            "chunk-assembled frame must be byte-identical to full encode"
+        );
+    }
+
+    /// Empty updated list and empty removed list — the degenerate case. Still
+    /// has to be a valid frame that decodes correctly.
+    #[test]
+    fn chunk_assembled_frame_with_empty_lists() {
+        let header = sample_header();
+        let via_chunks = encode_server_delta_from_chunks(&header, &[], &[]).unwrap();
+
+        let decoded = decode_server(&via_chunks).unwrap();
+        let ServerFrame::Delta(payload) = decoded;
+        assert_eq!(payload.source_cluster_id, header.source_cluster_id);
+        assert_eq!(payload.seq, header.seq);
+        assert_eq!(payload.tick, header.tick);
+        assert_eq!(payload.timestamp, header.timestamp);
+        assert!(payload.updated.is_empty());
+        assert!(payload.removed.is_empty());
+    }
+
+    /// Single entity, empty removed list — verifies the varint-prefix machinery
+    /// around a single chunk is correct.
+    #[test]
+    fn chunk_assembled_frame_with_single_entity() {
+        let header = sample_header();
+        let e1 = sample_entity();
+        let chunk1 = encode_entity(&e1);
+
+        let via_chunks =
+            encode_server_delta_from_chunks(&header, &[chunk1.as_slice()], &[]).unwrap();
+
+        let decoded = decode_server(&via_chunks).unwrap();
+        let ServerFrame::Delta(payload) = decoded;
+        assert_eq!(payload.updated.len(), 1);
+        assert_eq!(payload.updated[0], e1);
+        assert!(payload.removed.is_empty());
+    }
+
+    /// Larger list (> 127 entities) forces the varint length prefix to spill
+    /// into a second byte. Ensures the length encoding actually handles the
+    /// multi-byte varint case rather than accidentally working only for small
+    /// counts.
+    #[test]
+    fn chunk_assembled_frame_with_multi_byte_varint_length() {
+        let header = sample_header();
+        let mut entities = Vec::new();
+        let mut chunks = Vec::new();
+        for i in 0..200_u128 {
+            let e = EntityState {
+                entity_id: Uuid::from_u128(i),
+                cluster_id: Uuid::nil(),
+                position: Vec3::new(i as f64, 0.0, 0.0),
+                velocity: Vec3::new(0.0, 0.0, 0.0),
+                user_data: Vec::new(),
+            };
+            chunks.push(encode_entity(&e));
+            entities.push(e);
+        }
+        let chunk_refs: Vec<&[u8]> = chunks.iter().map(|c| c.as_slice()).collect();
+
+        let via_chunks = encode_server_delta_from_chunks(&header, &chunk_refs, &[]).unwrap();
+
+        let via_full = encode_server(&ServerFrame::Delta(DeltaPayload {
+            source_cluster_id: header.source_cluster_id,
+            seq: header.seq,
+            tick: header.tick,
+            timestamp: header.timestamp,
+            updated: entities.clone(),
+            removed: Vec::new(),
+        }))
+        .unwrap();
+
+        assert_eq!(via_chunks, via_full);
+
+        let decoded = decode_server(&via_chunks).unwrap();
+        let ServerFrame::Delta(payload) = decoded;
+        assert_eq!(payload.updated.len(), 200);
+        assert_eq!(payload.updated[150], entities[150]);
+    }
+
+    /// A subscriber selecting a subset of entities — the AOI use case. The
+    /// subset-of-chunks frame must be a valid, decodable frame containing
+    /// only the selected entities.
+    #[test]
+    fn chunk_assembled_frame_supports_subset_selection() {
+        let header = sample_header();
+        let e1 = EntityState {
+            entity_id: Uuid::from_u128(1),
+            cluster_id: Uuid::nil(),
+            position: Vec3::new(1.0, 0.0, 0.0),
+            velocity: Vec3::new(0.0, 0.0, 0.0),
+            user_data: Vec::new(),
+        };
+        let e2 = EntityState {
+            entity_id: Uuid::from_u128(2),
+            cluster_id: Uuid::nil(),
+            position: Vec3::new(2.0, 0.0, 0.0),
+            velocity: Vec3::new(0.0, 0.0, 0.0),
+            user_data: Vec::new(),
+        };
+        let e3 = EntityState {
+            entity_id: Uuid::from_u128(3),
+            cluster_id: Uuid::nil(),
+            position: Vec3::new(3.0, 0.0, 0.0),
+            velocity: Vec3::new(0.0, 0.0, 0.0),
+            user_data: Vec::new(),
+        };
+        let c1 = encode_entity(&e1);
+        let c2 = encode_entity(&e2);
+        let c3 = encode_entity(&e3);
+
+        // Producer pre-encodes all three entities once. Subscriber takes only
+        // the first and third — the AOI filter result.
+        let via_chunks =
+            encode_server_delta_from_chunks(&header, &[c1.as_slice(), c3.as_slice()], &[])
+                .unwrap();
+
+        let decoded = decode_server(&via_chunks).unwrap();
+        let ServerFrame::Delta(payload) = decoded;
+        assert_eq!(payload.updated.len(), 2);
+        assert_eq!(payload.updated[0], e1);
+        assert_eq!(payload.updated[1], e3);
+
+        // Sanity: the other chunk reference still produces its own independent
+        // encoding — per-entity chunks are not consumed by assembly.
+        assert!(!c2.is_empty(), "unused chunks remain usable");
+    }
+
+    /// Chunks carrying non-empty `user_data` (JSON bytes today) must pass
+    /// through correctly. Guards against accidental user_data mangling in the
+    /// splice path.
+    #[test]
+    fn chunk_assembled_frame_preserves_user_data_bytes() {
+        let header = sample_header();
+        let e = EntityState {
+            entity_id: Uuid::from_u128(42),
+            cluster_id: Uuid::from_u128(99),
+            position: Vec3::new(1.0, 2.0, 3.0),
+            velocity: Vec3::new(0.0, 0.0, 0.0),
+            user_data: br#"{"hp":99,"status":"poisoned"}"#.to_vec(),
+        };
+        let chunk = encode_entity(&e);
+
+        let via_chunks =
+            encode_server_delta_from_chunks(&header, &[chunk.as_slice()], &[]).unwrap();
+
+        let decoded = decode_server(&via_chunks).unwrap();
+        let ServerFrame::Delta(payload) = decoded;
+        assert_eq!(payload.updated.len(), 1);
+        assert_eq!(payload.updated[0].user_data, e.user_data);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the cluster-WS broadcast fan-out regression introduced in #30 (arcane-wire binary frames) and removes the dual-format JSON+binary outbound path that forced the regression in the first place.

## The regression

Commit `9573dd0` moved broadcast serialization from producer-side (once per tick per cluster) to subscriber-side (once per client per tick) so each client could choose its format. Cost profile:

| | Before `9573dd0` | After `9573dd0` | Shape B (this PR) |
|---|---|---|---|
| Broadcast channel carries | `String` (pre-encoded JSON) | `Arc<EntityStateDelta>` (struct) | `Arc<PreEncodedTick>` (per-entity byte chunks) |
| Per-tick serialization | O(1) per cluster | O(N clients) per cluster | O(N entities) per cluster |
| Per-subscriber cost | Byte forward | **Full delta re-serialization** | Arc clones + chunk concat |

Measured impact on the AWS 2-cluster Arcane benchmark: ceiling **regressed from 2000 players → 1250 players**, with full cluster unresponsiveness (including `/stats` endpoint) at 1500. The single-threaded tokio WS runtime couldn't keep up with the per-subscriber serialization burden at scale.

## The fix

**Shape B** serializes each entity once per tick at the producer, into a postcard byte chunk, wrapped in `Arc<Vec<u8>>` and shared across all subscribers. Per-subscriber outbound frame assembly uses a new `arcane-wire` helper that produces a wire-compatible `ServerFrame::Delta` by concatenating pre-encoded chunks — bit-for-bit identical to what `encode_server(...)` would emit on the fully-materialized payload, but without re-serializing any entity.

- Per-tick cost: **O(entity count)** serialization work at the producer, once. Subscribers do Arc clones + byte concatenation only.
- **AOI-ready:** a subscriber wanting only a subset of entities simply passes a filtered slice to the chunk-assembly helper. No re-serialization when AOI lands.

## JSON removed entirely — "replace, don't accumulate"

Pre-this-PR, the WS server accepted `Message::Text` (JSON) and `Message::Binary` (postcard) inbound, mirrored whichever the client sent last on outbound, and had a `prefer_binary` per-client flag. That coexistence is what forced the subscriber-side-serialization pattern in the first place: each client could want a different format, so the channel had to carry the un-serialized struct.

With Shape B's producer-side serialization, supporting two formats would mean serializing every entity twice per tick. The right answer is to pick one format. The swarm driver already speaks binary exclusively (commit `ffdca0f`). The UE5 adapter has a follow-up issue to migrate.

Removed:
- `PlayerStateMessage`, `Vec3Message`, `TypePeek`, `ClientMessage` JSON types
- `parse_player_state`, `parse_game_action`, `parse_client_message`, `is_finite_vec3` JSON parsers
- `wire_delta_from_internal` (replaced by per-entity `encode_entity_chunk`)
- `Message::Text` inbound handling
- `prefer_binary` flag and the JSON outbound branch
- All JSON-path tests

## arcane-wire additions

- `DeltaHeader` — fixed-size header fields used with the chunk-assembly helper.
- `encode_server_delta_from_chunks(header, entity_chunks, removed)` — the core new primitive. Byte-for-byte parity with `encode_server` verified by test.
- `encode_entity_state` / `decode_entity_state` / `Error` — helpers so `arcane-infra` doesn't take a direct `postcard` dependency, matching the existing wire-crate design intent ("Callers should not be able to serialize arbitrary types through this crate").

## Test plan

- [x] `cargo test -p arcane-wire` — 17/17 pass, including `chunk_assembled_frame_matches_full_encode_byte_for_byte`, `chunk_assembled_frame_with_multi_byte_varint_length` (200-entity multi-byte varint edge case), and `chunk_assembled_frame_supports_subset_selection` (the AOI hook case).
- [x] `cargo test -p arcane-infra --features cluster-ws` — all tests green. New tests cover `encode_entity_chunk`, `pre_encode_tick`, and the cross-cutting `shape_b_outbound_bytes_match_full_encode_byte_for_byte` byte-for-byte parity property.
- [x] `cargo test --workspace --features cluster-ws,manager,spacetimedb-persist` — all workspace suites green.
- [x] `cargo clippy -p arcane-wire -p arcane-infra --features cluster-ws --all-targets -- -D warnings` — clean.
- [x] `benchmark-cluster` in the arcane-scaling-benchmarks repo compiles cleanly against this branch.
- [x] Swarm driver's inbound path accepts both `Message::Text` and `Message::Binary` (both just record byte length) — fully compatible with Shape B's binary-only outbound.
- [ ] **After merge:** bump the arcane submodule in arcane-scaling-benchmarks, rebuild the Docker image, rerun the 2-cluster AWS benchmark. Expected: ceiling ≥ 2000. If the 2000 ceiling recovers cleanly, multi-threaded tokio WS runtime (task #50) is the next lever.

## Follow-ups not in this PR

- UE5 adapter migration to `arcane-wire` binary (separate PR on `arcane-client-unreal`).
- Arcane-scaling-benchmarks submodule bump + image rebuild + rerun.
- Task #50 (multi-threaded tokio) if we want to push past 2000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)