### PR TITLE
feat(infra): saturation counters in cluster /stats

### DIFF
--- a/crates/arcane-infra/src/cluster_stats.rs
+++ b/crates/arcane-infra/src/cluster_stats.rs
@@ -26,6 +26,21 @@ pub struct ClusterStats {
     pub parse_failures: AtomicU64,
     /// Inbound text bytes received by this cluster's WebSocket server.
     pub bytes_in: AtomicU64,
+    /// Outbound WebSocket bytes sent to connected subscribers (cumulative
+    /// across the run). Used alongside `ws_accepts` to compute egress rate.
+    pub bytes_out: AtomicU64,
+    /// Number of times a subscriber received `RecvError::Lagged(n)` from the
+    /// broadcast channel — i.e. the producer emitted frames faster than that
+    /// subscriber drained them. Non-zero under fan-out saturation.
+    pub broadcast_lagged_events: AtomicU64,
+    /// Sum of `n` across all `Lagged(n)` events — total broadcast frames that
+    /// subscribers skipped. Scales with both how bad the lag is and how many
+    /// subscribers are affected.
+    pub broadcast_lagged_frames: AtomicU64,
+    /// WebSocket send attempts that returned an error (peer closed or
+    /// transport failure). Non-zero under WS-egress saturation or client
+    /// drops. Paired with `ws_accepts` to compute active-connection churn.
+    pub ws_send_errors: AtomicU64,
     /// Current entity count observed at the end of the most recent tick.
     pub entities_current: AtomicU64,
     /// Peak entity count observed since startup.
@@ -84,13 +99,17 @@ impl ClusterStats {
     /// so the harness's SSM/poll path is cheap.
     pub fn to_json(&self, cluster_id: &str) -> String {
         format!(
-            r#"{{"cluster_id":"{}","ws_accepts":{},"msgs_player_state":{},"msgs_game_action":{},"parse_failures":{},"bytes_in":{},"entities_current":{},"entities_peak":{},"unique_entity_ids_seen":{},"tick":{},"seq":{},"last_tick_us":{}}}"#,
+            r#"{{"cluster_id":"{}","ws_accepts":{},"msgs_player_state":{},"msgs_game_action":{},"parse_failures":{},"bytes_in":{},"bytes_out":{},"broadcast_lagged_events":{},"broadcast_lagged_frames":{},"ws_send_errors":{},"entities_current":{},"entities_peak":{},"unique_entity_ids_seen":{},"tick":{},"seq":{},"last_tick_us":{}}}"#,
             cluster_id,
             self.ws_accepts.load(Ordering::Relaxed),
             self.msgs_player_state.load(Ordering::Relaxed),
             self.msgs_game_action.load(Ordering::Relaxed),
             self.parse_failures.load(Ordering::Relaxed),
             self.bytes_in.load(Ordering::Relaxed),
+            self.bytes_out.load(Ordering::Relaxed),
+            self.broadcast_lagged_events.load(Ordering::Relaxed),
+            self.broadcast_lagged_frames.load(Ordering::Relaxed),
+            self.ws_send_errors.load(Ordering::Relaxed),
             self.entities_current.load(Ordering::Relaxed),
             self.entities_peak.load(Ordering::Relaxed),
             self.unique_entity_ids_count(),
@@ -188,6 +207,10 @@ mod tests {
         s.msgs_game_action.store(7, Ordering::Relaxed);
         s.parse_failures.store(2, Ordering::Relaxed);
         s.bytes_in.store(12345, Ordering::Relaxed);
+        s.bytes_out.store(67890, Ordering::Relaxed);
+        s.broadcast_lagged_events.store(4, Ordering::Relaxed);
+        s.broadcast_lagged_frames.store(17, Ordering::Relaxed);
+        s.ws_send_errors.store(1, Ordering::Relaxed);
         s.set_entities(42);
         s.tick.store(500, Ordering::Relaxed);
         s.seq.store(501, Ordering::Relaxed);
@@ -203,6 +226,10 @@ mod tests {
         assert_eq!(parsed["msgs_game_action"], 7);
         assert_eq!(parsed["parse_failures"], 2);
         assert_eq!(parsed["bytes_in"], 12345);
+        assert_eq!(parsed["bytes_out"], 67890);
+        assert_eq!(parsed["broadcast_lagged_events"], 4);
+        assert_eq!(parsed["broadcast_lagged_frames"], 17);
+        assert_eq!(parsed["ws_send_errors"], 1);
         assert_eq!(parsed["entities_current"], 42);
         assert_eq!(parsed["entities_peak"], 42);
         assert_eq!(parsed["unique_entity_ids_seen"], 2);

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -307,13 +307,20 @@ async fn ws_loop(
                                     Ok(b) => b,
                                     Err(_) => continue,
                                 };
+                                let byte_len = bytes.len() as u64;
                                 if ws_stream.send(Message::Binary(bytes)).await.is_err() {
+                                    stats.ws_send_errors.fetch_add(1, Ordering::Relaxed);
                                     break;
                                 }
+                                stats.bytes_out.fetch_add(byte_len, Ordering::Relaxed);
                             }
                             Err(error) => {
                                 // Backpressure/loss policy: tolerate dropped broadcast frames (`Lagged`)
                                 // and continue with freshest state; terminate only when channel is closed.
+                                if let tokio::sync::broadcast::error::RecvError::Lagged(n) = error {
+                                    stats.broadcast_lagged_events.fetch_add(1, Ordering::Relaxed);
+                                    stats.broadcast_lagged_frames.fetch_add(n, Ordering::Relaxed);
+                                }
                                 if !should_keep_ws_loop_running_on_broadcast_error(&error) {
                                     break;
                                 }


### PR DESCRIPTION
## Summary
- Adds four counters to the existing \`/stats\` endpoint so the benchmark harness can attribute ceiling failures to a specific saturation mode instead of reporting a black-box ramp timeout:
  - \`bytes_out\` — cumulative outbound WS egress bytes
  - \`broadcast_lagged_events\` — number of \`RecvError::Lagged\` errors observed by subscribers (producer outran subscriber drain)
  - \`broadcast_lagged_frames\` — sum of \`n\` across \`Lagged(n)\` events (total frames subscribers skipped)
  - \`ws_send_errors\` — WebSocket send attempts that returned an error (slow-client drops / transport failures)
- Increments live in \`ws_server.rs\` on the existing send/recv paths — no new critical-path work.
- Paired with the driver telemetry fix in **arcane_swarm#11** — together they give a tier-failure attribution path: driver-saturated vs. cluster-saturated, and (within cluster) broadcast fan-out vs. WS egress.

## Test plan
- [x] \`cargo check -p arcane-infra --features cluster-ws\`
- [x] \`cargo clippy -p arcane-infra --features cluster-ws --all-targets -- -D warnings\`
- [x] \`cargo test -p arcane-infra --features cluster-ws\` — 18 ws_server/cluster_stats tests pass, including updated \`to_json_includes_all_counters\`
- [x] \`cargo fmt --all -- --check\`
- [ ] Next AWS rerun: confirm per-cluster /stats snapshots at each tier boundary include non-zero \`bytes_out\` and zero \`broadcast_lagged_events\` while healthy; watch for growth on the failure tier

## Follow-ups (separate PRs)
- Benchmarks repo: per-tier /stats snapshot + most-overloaded classifier (issue/task #60)
- Arcane repo: multi-threaded tokio runtime for cluster WS (task #50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)