### PR TITLE
perf(infra): multi-thread tokio runtime for cluster WS server

### DIFF
--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -225,7 +225,14 @@ pub fn run_ws_server(
     stats: Arc<ClusterStats>,
 ) {
     std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
+        // Multi-thread runtime so broadcast fan-out (one subscriber task per
+        // connected client) and inbound WS-frame decode can run concurrently
+        // across CPU cores. The pre-Shape-B regression forced every subscriber
+        // to serialize on a single reactor; even after Shape B removed the
+        // per-subscriber re-serialization, the subscriber send + inbound decode
+        // workload still scales with connected-client count and benefits from
+        // parallel execution. Defaults to one worker thread per available core.
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .expect("tokio runtime");


### PR DESCRIPTION
## Summary
- The cluster WS server ran on a **single-thread** tokio runtime (\`new_current_thread\`). Every per-subscriber task and every inbound-frame decode serialized on one reactor thread, saturating a single CPU core at high connected-client counts even after the Shape B producer-side fix.
- Switch to \`new_multi_thread\`. Defaults to one worker thread per available CPU (8 on a c7i.2xlarge cluster node).
- No API change. All 18 ws_server/cluster_stats tests pass; existing Arc/Mutex-guarded shared state was already Send+Sync.

## Context
This is the third and final code change in the "attribute ceiling failures to a specific component" sequence that was requested after the Shape B verification run restored the baseline 2000-player ceiling without improving it:

1. **arcane_swarm#11** (merged) — driver CPU/RSS telemetry emitted during control mode
2. **arcane#37** (merged) — saturation counters in cluster \`/stats\` (\`bytes_out\`, \`broadcast_lagged_events/frames\`, \`ws_send_errors\`)
3. **arcane-scaling-benchmarks#33** (merged) — per-tier \`/stats\` snapshot + most-overloaded classifier
4. **This PR** — hand the cluster all available cores so the classifier has room to observe where saturation actually moves to

## Test plan
- [x] \`cargo check -p arcane-infra --features cluster-ws\`
- [x] \`cargo clippy -p arcane-infra --features cluster-ws --all-targets -- -D warnings\`
- [x] \`cargo test -p arcane-infra --features cluster-ws\` — all suites pass
- [x] \`cargo fmt --all -- --check\`
- [ ] Next AWS rerun: compare cluster-node CPU utilization (was pinned to ~1 core) and ceiling vs. prior 2000-player run

🤖 Generated with [Claude Code](https://claude.com/claude-code)