### PR TITLE
perf(infra): parallel pre-encoding via rayon in cluster tick

### DIFF
--- a/crates/arcane-infra/Cargo.toml
+++ b/crates/arcane-infra/Cargo.toml
@@ -12,6 +12,7 @@ arcane-pool = { path = "../arcane-pool" }
 arcane-wire = { path = "../arcane-wire" }
 axum = { version = "0.7", optional = true }
 futures-util = { version = "0.3", optional = true }
+rayon = { version = "1", optional = true }
 redis = "0.27"
 reqwest = { version = "0.12", features = ["json", "blocking"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -23,7 +24,7 @@ uuid = { version = "1.0", features = ["v4"] }
 [features]
 default = ["cluster-ws"]
 manager = ["dep:axum", "dep:tokio"]
-cluster-ws = ["dep:tokio", "dep:tokio-tungstenite", "dep:futures-util"]
+cluster-ws = ["dep:tokio", "dep:tokio-tungstenite", "dep:futures-util", "dep:rayon"]
 spacetimedb-persist = ["dep:reqwest"]
 
 [[bin]]

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -43,6 +43,7 @@ use arcane_wire::{
     PlayerStatePayload, Vec3 as WireVec3,
 };
 use futures_util::{sink::SinkExt, stream::StreamExt};
+use rayon::prelude::*;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
@@ -145,7 +146,27 @@ struct PreEncodedTick {
 
 /// Convert an [`EntityStateDelta`] to a [`PreEncodedTick`] by serializing
 /// each entity once. Called by the producer task every tick.
+///
+/// Entity encoding is **parallelized across rayon's thread pool** via
+/// `par_iter`. At scale the per-tick encode is O(P) in total world entity
+/// count (every cluster encodes every entity it broadcasts, including
+/// remote entities replicated from neighbors under full-mesh). On an
+/// 8-vCPU cluster node this work was the dominant serial bottleneck in
+/// the tick budget — measured at ~35 ms/tick for P=6750. Distributing it
+/// across cores cuts the wall-clock proportionally (memory-bandwidth-
+/// bounded, so usually 4-6× on 8 cores, not 8×).
+///
+/// Correctness: the output order must match the input order because
+/// `assemble_outbound_frame` and downstream decoders do not have primary
+/// keys on the chunk list. `rayon::par_iter().map(...).collect()`
+/// preserves iteration order, so the resulting `Vec` is bit-for-bit
+/// identical to the serial version's output.
 fn pre_encode_tick(delta: &EntityStateDelta) -> PreEncodedTick {
+    let entity_chunks: Vec<Arc<Vec<u8>>> = delta
+        .updated
+        .par_iter()
+        .map(|e| Arc::new(encode_entity_chunk(e)))
+        .collect();
     PreEncodedTick {
         header: DeltaHeader {
             source_cluster_id: delta.source_cluster_id,
@@ -153,11 +174,7 @@ fn pre_encode_tick(delta: &EntityStateDelta) -> PreEncodedTick {
             tick: delta.tick,
             timestamp: delta.timestamp,
         },
-        entity_chunks: delta
-            .updated
-            .iter()
-            .map(|e| Arc::new(encode_entity_chunk(e)))
-            .collect(),
+        entity_chunks,
         removed: delta.removed.clone(),
     }
 }
@@ -636,5 +653,63 @@ mod tests {
             via_shape_b, via_reference,
             "Shape B must produce bit-identical output to the full-encode path"
         );
+    }
+
+    /// Parallel pre-encoding must preserve chunk ORDER, because
+    /// `assemble_outbound_frame` and the downstream decoder rely on it
+    /// (the `updated` list has no primary key that could re-order it
+    /// after the fact). `rayon::par_iter().map().collect::<Vec<_>>()`
+    /// guarantees iteration-order preservation, but this test pins the
+    /// guarantee so a future refactor to `collect_into_vec` or similar
+    /// can't silently break it — the produced outbound frame would
+    /// deserialize entities in scrambled order, which subscribers would
+    /// see as teleporting players.
+    #[test]
+    fn parallel_pre_encode_preserves_entity_order() {
+        // Large enough to cross rayon's work-splitting threshold
+        // (typically 1 item per chunk but worth making it meaningful).
+        let mut entities = Vec::with_capacity(200);
+        for i in 0..200_u128 {
+            let mut e = EntityStateEntry::new(
+                Uuid::from_u128(i),
+                Uuid::from_u128(99),
+                Vec3::new(i as f64 * 1.5, 0.0, i as f64 * -0.25),
+                Vec3::new(0.0, 0.0, 0.0),
+            );
+            e.user_data = serde_json::json!({"order_marker": i as u64});
+            entities.push(e);
+        }
+        let delta = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(99),
+            seq: 1,
+            tick: 2,
+            timestamp: 3.0,
+            updated: entities.clone(),
+            removed: vec![],
+        };
+
+        let pre_tick = pre_encode_tick(&delta);
+
+        // Decode each chunk back and verify its entity_id matches the
+        // input entity at the same index — parallel execution must not
+        // reorder.
+        assert_eq!(pre_tick.entity_chunks.len(), entities.len());
+        for (i, chunk) in pre_tick.entity_chunks.iter().enumerate() {
+            let decoded = arcane_wire::decode_entity_state(chunk).expect("chunk decodes");
+            assert_eq!(
+                decoded.entity_id, entities[i].entity_id,
+                "chunk at index {} was reordered by parallel encoding",
+                i
+            );
+        }
+
+        // Also verify end-to-end frame decodes identically to what a
+        // serial encode would have produced.
+        let bytes = assemble_outbound_frame(&pre_tick).expect("assemble");
+        let decoded = arcane_wire::decode_server(&bytes).expect("decode");
+        let ServerFrame::Delta(payload) = decoded;
+        for (i, e) in payload.updated.iter().enumerate() {
+            assert_eq!(e.entity_id, entities[i].entity_id);
+        }
     }
 }


### PR DESCRIPTION
## Summary

\`pre_encode_tick\`'s O(P) encode loop was the dominant serial cost in the cluster's per-tick budget — about **35 ms at P = 6750** on a single core, while the other 7 vCPUs sat idle. Replace the serial \`iter().map(...)\` with \`rayon::par_iter().map(...)\` so encoding distributes across all cores of the cluster node.

## Correctness

Downstream consumers (\`assemble_outbound_frame\` and \`arcane_wire::decode_server\`) treat the \`updated\` chunk list as positional — there's no primary key that could re-order it after the fact. \`rayon::par_iter().map().collect::<Vec<_>>()\` preserves iteration order, so the encoded output is bit-for-bit identical to the serial path. Pinned by two tests:

- The existing \`shape_b_outbound_bytes_match_full_encode_byte_for_byte\` — still passes; parallel encoding produces the same bytes as a reference \`arcane_wire::encode_server(ServerFrame::Delta(...))\`.
- New \`parallel_pre_encode_preserves_entity_order\` — 200 entities with distinct user_data markers; verifies each chunk at index \`i\` decodes back to the entity at input index \`i\`, both at chunk level and after full frame decode.

## Expected impact

- **Encode wall-clock**: ~4-6× reduction on 8 vCPUs (memory-bandwidth-bounded; ideal 8× not expected).
- **Client-perceived latency at 6c/6750 players**: plausibly drops from 195 ms → ~130-150 ms based on the estimate that encode was ~35 ms of the ~45 ms per-tick wall-clock.
- **Scaling shape changes**: per-cluster tick becomes O(P / cores) instead of O(P). More clusters should now actually move the ceiling up rather than saturating at the ~4-cluster sweet spot we measured.

Will be empirically verified on the next AWS benchmark rerun. Filed as task #67.

## Test plan
- [x] \`cargo check -p arcane-infra --features cluster-ws\`
- [x] \`cargo test -p arcane-infra --features cluster-ws --lib\` — 19 passing (18 existing + 1 new)
- [ ] End-to-end AWS rerun of 4c and 6c on c7i.2xlarge — expect ceilings to move up, latency climb to flatten

🤖 Generated with [Claude Code](https://claude.com/claude-code)