### PR TITLE
feat(infra): env-driven cluster tick rate via BENCHMARK_TICK_RATE_HZ

### DIFF
--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -27,7 +27,6 @@ use crate::neighbor_subscriber::spawn_neighbor_subscriber;
 use crate::spacetimedb_persist::SpacetimeDbPersist;
 use crate::{ClusterServer, ReplicationChannelManager};
 
-const TICK_RATE_HZ: u64 = 20;
 const LOG_EVERY_TICKS: u64 = 100;
 /// Log parseable server stats every N ticks (for benchmark: entities, clusters, tick_ms).
 const LOG_STATS_EVERY_TICKS: u64 = 40;
@@ -56,8 +55,8 @@ fn merge_with_neighbor_latest(
 /// Each tick, after applying client updates, calls `extra_entities_for_tick(tick_count)` and pushes any returned entries into the server (e.g. demo agents from arcane-demo).
 ///
 /// When `simulation` is `Some`, [`ClusterSimulation::on_tick`] runs after those steps and before
-/// [`ClusterServer::tick`], using `1 / TICK_RATE_HZ` as `dt_seconds`.
-/// Never returns on success (infinite loop); returns Err only if setup fails.
+/// [`ClusterServer::tick`], using `1 / tick_rate_hz()` as `dt_seconds` (env-driven, see
+/// [`crate::tick_rate`]). Never returns on success (infinite loop); returns Err only if setup fails.
 #[cfg(feature = "cluster-ws")]
 pub fn run_cluster_loop<F>(
     cluster_id: Uuid,
@@ -102,17 +101,18 @@ where
     spawn_neighbor_subscriber(redis_url.clone(), neighbor_ids.clone(), neighbor_tx);
     let mut neighbor_latest: HashMap<Uuid, Vec<EntityStateEntry>> = HashMap::new();
 
+    let tick_rate_hz = crate::tick_rate::tick_rate_hz();
     eprintln!(
         "arcane-cluster started cluster_id={} neighbors={} tick_rate={}Hz",
         cluster_id,
         neighbor_ids.len(),
-        TICK_RATE_HZ
+        tick_rate_hz
     );
 
     #[cfg(feature = "spacetimedb-persist")]
     let persist = SpacetimeDbPersist::from_env();
 
-    let interval = Duration::from_millis(1000 / TICK_RATE_HZ);
+    let interval = Duration::from_millis(1000 / tick_rate_hz);
     let dt_seconds = interval.as_secs_f64();
     let mut tick_count: u64 = 0;
 

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -20,6 +20,7 @@ pub mod replication_channel_manager;
 pub mod rpc_handler;
 #[cfg(feature = "spacetimedb-persist")]
 pub mod spacetimedb_persist;
+pub mod tick_rate;
 
 #[cfg(feature = "cluster-ws")]
 pub mod cluster_runner;

--- a/crates/arcane-infra/src/spacetimedb_persist.rs
+++ b/crates/arcane-infra/src/spacetimedb_persist.rs
@@ -22,8 +22,6 @@ use std::time::{Duration, Instant};
 
 use arcane_core::replication_channel::EntityStateEntry;
 
-const TICK_RATE_HZ: u64 = 20;
-
 #[derive(serde::Serialize)]
 struct SpacetimeUuid {
     __uuid__: u128,
@@ -98,7 +96,12 @@ impl SpacetimeDbPersist {
         if !enabled {
             return None;
         }
-        let interval_ticks = (TICK_RATE_HZ / hz.max(1)).max(1);
+        // Persist cadence is computed from the resolved cluster tick rate so the
+        // SpacetimeDB snapshot rate stays at the requested Hz regardless of the
+        // simulation tick rate. e.g. cluster at 30 Hz + persist at 1 Hz =
+        // every 30 ticks.
+        let tick_rate_hz = crate::tick_rate::tick_rate_hz();
+        let interval_ticks = (tick_rate_hz / hz.max(1)).max(1);
         let max_batch_size: usize = std::env::var("SPACETIMEDB_PERSIST_BATCH_SIZE")
             .ok()
             .and_then(|s| s.parse().ok())

--- a/crates/arcane-infra/src/tick_rate.rs
+++ b/crates/arcane-infra/src/tick_rate.rs
@@ -1,0 +1,69 @@
+//! Resolved cluster simulation tick rate, sourced from the environment.
+//!
+//! Single source of truth for `cluster_runner` (drives the tick loop) and
+//! `spacetimedb_persist` (computes the persist cadence in ticks). Reading the
+//! env var in one place keeps the two from drifting if a future change moves
+//! the default.
+//!
+//! The clamp at [5, 128] Hz is wide enough to span the MMO band (5–30 Hz) and
+//! the shooter/competitive band (30–128 Hz). Outside that range, callers
+//! likely typo'd the env var and should see the silently-clamped value rather
+//! than e.g. a 1 Hz tick that produces "the cluster looks alive but no entity
+//! has moved" pathology.
+//!
+//! Default 20 Hz preserves the historical baseline: prior tick-rate constants
+//! were `const TICK_RATE_HZ: u64 = 20`, and configs/tfvars in callers that
+//! don't set the env var should see no behavioral change.
+
+const ENV_VAR: &str = "BENCHMARK_TICK_RATE_HZ";
+const DEFAULT_HZ: u64 = 20;
+const MIN_HZ: u64 = 5;
+const MAX_HZ: u64 = 128;
+
+/// Pure resolver: given the raw env value (Some = env var was set, None =
+/// unset), returns the resolved tick rate. Extracted from the env-reading
+/// shell so tests can exercise every branch without mutating process env
+/// (which races across the test runner's threads).
+fn resolve(raw: Option<&str>) -> u64 {
+    raw.and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_HZ)
+        .clamp(MIN_HZ, MAX_HZ)
+}
+
+/// Resolved cluster tick rate in Hz, clamped to [MIN_HZ, MAX_HZ]. Cheap to
+/// call repeatedly — it re-reads the env var each time — but typical callers
+/// resolve it once at startup.
+pub fn tick_rate_hz() -> u64 {
+    resolve(std::env::var(ENV_VAR).ok().as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_20_when_unset() {
+        assert_eq!(resolve(None), DEFAULT_HZ);
+    }
+
+    #[test]
+    fn parses_env_value() {
+        assert_eq!(resolve(Some("30")), 30);
+        assert_eq!(resolve(Some("60")), 60);
+    }
+
+    #[test]
+    fn clamps_below_min() {
+        assert_eq!(resolve(Some("1")), MIN_HZ);
+    }
+
+    #[test]
+    fn clamps_above_max() {
+        assert_eq!(resolve(Some("256")), MAX_HZ);
+    }
+
+    #[test]
+    fn falls_back_on_unparseable_value() {
+        assert_eq!(resolve(Some("not-a-number")), DEFAULT_HZ);
+    }
+}


### PR DESCRIPTION
## Summary

Make the cluster simulation tick rate runtime-configurable via the
`BENCHMARK_TICK_RATE_HZ` env var. Default stays 20 Hz so existing
deployments are unaffected; benchmark drivers that want a different
rate set the env var on the cluster container.

- New `tick_rate::tick_rate_hz()` helper reads the env var, parses it,
  and clamps to `[5, 128]` Hz (wide enough to span MMO 5–30 Hz and
  shooter 30–128 Hz; outside that range, callers likely typo'd the var).
- `cluster_runner.rs` and `spacetimedb_persist.rs` both call the helper
  so the simulation interval and SpacetimeDB persist cadence stay
  coherent. The persist config stays in Hz (`SPACETIMEDB_PERSIST_HZ`),
  so a 1 Hz persist is still 1 Hz at any cluster tick rate.
- Pure parser extracted as `resolve(Option<&str>) -> u64` so the unit
  tests don't race the test runner over a shared env var.

## Why

Resolves the arcane side of brainy-bots/arcane-scaling-benchmarks#51.
At the 7,250-player ceiling measured 2026-04-26, cluster outbound NIC
is the binding bottleneck and tick rate is one of the two direct knobs
on outbound bytes/sec. Making tick rate measurable lets us publish a
30 Hz MMO-class headline (and later a 60 Hz shooter-class run) without
a rebuild cycle per measurement.

## Test plan

- [x] 5 unit tests cover default, parse, clamp-low, clamp-high,
  unparseable. All pass.
- [x] Full workspace test suite still green.
- [ ] Cloud-side smoke (covered by the benchmark-repo companion PR).

## Out of scope

- The `BUFF_DURATION_TICKS` constant in `benchmark-cluster` (lives in
  the benchmark repo) — handled by the companion PR which scales it
  off `ctx.dt_seconds`.
- SpacetimeDB-only module's tick rate — that side stays at 20 Hz; the
  comparison is now generous to SpacetimeDB on the tick-rate axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)