### PR TITLE
feat(cluster): velocity-based dead reckoning on broadcast (#46)

### DIFF
--- a/crates/arcane-infra/src/cluster_server.rs
+++ b/crates/arcane-infra/src/cluster_server.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext, GameAction};
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
+use arcane_wire::Vec3Q;
 use uuid::Uuid;
 
 use crate::ReplicationChannelManager;
@@ -15,6 +16,25 @@ use crate::ReplicationChannelManager;
 /// growth from misbehaving clients sending unique entity IDs. The cap applies to `add_entity`;
 /// entities injected by `simulate_before_tick` are not capped (they are server-authoritative).
 pub const DEFAULT_MAX_ENTITIES: usize = 100_000;
+
+/// Default resync cadence for velocity-based dead reckoning, in ticks. Every
+/// N ticks the cluster broadcasts every entity regardless of velocity change,
+/// so clients that missed a velocity-change broadcast (packet loss, late
+/// join) re-anchor to fresh server state. 60 ticks ≈ 2-3 sec wall-clock
+/// across the benchmark's tick range (20-60 Hz). Override via
+/// `ARCANE_RESYNC_EVERY_N_TICKS`.
+pub const DEFAULT_RESYNC_EVERY_N_TICKS: u64 = 60;
+
+/// Read the resync cadence from the environment. Clamped to `>= 1` so a
+/// misconfigured value can't accidentally disable resync entirely (which
+/// would leave dropped-velocity-change entities stale forever).
+fn resolve_resync_every_n_ticks() -> u64 {
+    std::env::var("ARCANE_RESYNC_EVERY_N_TICKS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_RESYNC_EVERY_N_TICKS)
+}
 
 /// One process per cluster. Runs simulation, replication, client connections.
 pub struct ClusterServer {
@@ -25,6 +45,17 @@ pub struct ClusterServer {
     entities: Mutex<HashMap<Uuid, EntityStateEntry>>,
     pending_removed: Mutex<Vec<Uuid>>,
     max_entities: usize,
+    /// Last-broadcast velocity per entity (quantized to wire form). Used for
+    /// velocity-based dead reckoning: an entity is omitted from a broadcast
+    /// when its current velocity quantizes identically to its last-broadcast
+    /// velocity. New entities and the periodic resync tick force inclusion.
+    /// Comparing in `Vec3Q` (i16) instead of `Vec3` (f64) means the skip
+    /// decision matches the client's view exactly — if the wire bytes
+    /// wouldn't change, the broadcast doesn't happen.
+    last_broadcast_velocity: Mutex<HashMap<Uuid, Vec3Q>>,
+    /// Resync cadence in ticks. Read once at construction from
+    /// `ARCANE_RESYNC_EVERY_N_TICKS`. See [`DEFAULT_RESYNC_EVERY_N_TICKS`].
+    resync_every_n_ticks: u64,
 }
 
 impl ClusterServer {
@@ -41,6 +72,8 @@ impl ClusterServer {
             entities: Mutex::new(HashMap::new()),
             pending_removed: Mutex::new(Vec::new()),
             max_entities,
+            last_broadcast_velocity: Mutex::new(HashMap::new()),
+            resync_every_n_ticks: resolve_resync_every_n_ticks(),
         }
     }
 
@@ -106,15 +139,63 @@ impl ClusterServer {
     }
 
     /// Advance simulation by one tick, build delta from current entities, broadcast to neighbors if set, and return the delta.
+    ///
+    /// **Velocity-based dead reckoning.** Entities whose current velocity
+    /// quantizes identically to their last-broadcast velocity are omitted
+    /// from the `updated` list (clients hold the last anchor and extrapolate
+    /// position locally via `pos(t) = pos_last + vel_last × (t − t_last)`).
+    /// First-broadcast entities and the periodic resync tick force inclusion
+    /// so packet-loss / late-join scenarios converge. The `removed` list is
+    /// always carried verbatim — removals can't be inferred client-side.
     pub fn tick(&self) -> EntityStateDelta {
         let t = self.tick.fetch_add(1, Ordering::Relaxed) + 1;
         let s = self.seq.fetch_add(1, Ordering::Relaxed) + 1;
 
+        // A resync tick rebroadcasts every entity (both for late joiners and
+        // to recover from any silently dropped velocity-change broadcasts).
+        // Tick 0 is impossible here (we just incremented), so the first
+        // resync naturally fires at tick `resync_every_n_ticks` rather than
+        // on the very first tick — that's fine, the first-broadcast path
+        // below already includes every entity once.
+        let is_resync_tick = t.is_multiple_of(self.resync_every_n_ticks);
+
         let (updated, removed) = {
             let entities = self.entities.lock().expect("entities lock");
-            let updated: Vec<EntityStateEntry> = entities.values().cloned().collect();
+            let mut last_vel = self
+                .last_broadcast_velocity
+                .lock()
+                .expect("last_broadcast_velocity lock");
+
+            // Collect entities that need broadcasting this tick. New entity
+            // (no last-broadcast record), velocity-quantum-changed entity,
+            // or every entity on a resync tick — otherwise skip and let the
+            // client extrapolate from its last anchor.
+            let mut updated: Vec<EntityStateEntry> = Vec::new();
+            for entry in entities.values() {
+                let current_vel_q = Vec3Q::from_vec3(arcane_wire::Vec3::new(
+                    entry.velocity.x,
+                    entry.velocity.y,
+                    entry.velocity.z,
+                ));
+                let include = match last_vel.get(&entry.entity_id) {
+                    None => true, // new entity — first broadcast
+                    Some(_) if is_resync_tick => true,
+                    Some(prev) => *prev != current_vel_q,
+                };
+                if include {
+                    last_vel.insert(entry.entity_id, current_vel_q);
+                    updated.push(entry.clone());
+                }
+            }
+
             let mut pending = self.pending_removed.lock().expect("pending_removed lock");
             let removed = std::mem::take(&mut *pending);
+            // Drop the dead-reckoning record for entities that just left so
+            // the map stays bounded by `entity_count`, not lifetime-unique
+            // ids ever seen.
+            for id in &removed {
+                last_vel.remove(id);
+            }
             (updated, removed)
         };
 

--- a/crates/arcane-infra/tests/cluster_server_tests.rs
+++ b/crates/arcane-infra/tests/cluster_server_tests.rs
@@ -287,3 +287,134 @@ fn simulate_before_tick_panicking_simulation_poisons_but_does_not_cascade() {
         "poisoned lock makes subsequent operations fail"
     );
 }
+
+// ── Velocity-based dead reckoning ─────────────────────────────────────────
+
+mod dead_reckoning {
+    use super::*;
+    use arcane_core::replication_channel::EntityStateEntry;
+    use arcane_core::Vec3;
+
+    fn entry(id: Uuid, vx: f64) -> EntityStateEntry {
+        EntityStateEntry::new(
+            id,
+            Uuid::nil(),
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(vx, 0.0, 0.0),
+        )
+    }
+
+    #[test]
+    fn first_broadcast_includes_every_entity_regardless_of_velocity() {
+        // First-ever broadcast must include each entity once so the client
+        // has an anchor to extrapolate from. Without this, a constant-velocity
+        // entity that just joined would never be sent at all.
+        let server = ClusterServer::new(Uuid::new_v4());
+        for i in 0..5_u128 {
+            server.add_entity(entry(Uuid::from_u128(i + 1), 0.0));
+        }
+        let delta = server.tick();
+        assert_eq!(delta.updated.len(), 5);
+    }
+
+    #[test]
+    fn unchanged_velocity_is_skipped_after_first_broadcast() {
+        // The whole point of dead reckoning: a moving-in-a-straight-line
+        // entity should produce one broadcast (the anchor), then nothing,
+        // until either velocity changes or a resync tick fires.
+        let server = ClusterServer::new(Uuid::new_v4());
+        let id = Uuid::from_u128(1);
+        server.add_entity(entry(id, 5.0));
+        let delta1 = server.tick();
+        assert_eq!(delta1.updated.len(), 1);
+
+        // Re-add the same entity with the same velocity so it stays in
+        // entities (add_entity is the only way the swarm side feeds state).
+        server.add_entity(entry(id, 5.0));
+        let delta2 = server.tick();
+        assert!(
+            delta2.updated.is_empty(),
+            "entity with unchanged velocity must be omitted from broadcast"
+        );
+    }
+
+    #[test]
+    fn changed_velocity_is_included() {
+        let server = ClusterServer::new(Uuid::new_v4());
+        let id = Uuid::from_u128(1);
+        server.add_entity(entry(id, 5.0));
+        let _ = server.tick();
+
+        // Velocity changes to 10.0 — the entity must be in the next delta
+        // so the client re-anchors before extrapolating further.
+        server.add_entity(entry(id, 10.0));
+        let delta = server.tick();
+        assert_eq!(delta.updated.len(), 1);
+        assert_eq!(delta.updated[0].velocity.x, 10.0);
+    }
+
+    #[test]
+    fn sub_quantum_velocity_change_is_treated_as_unchanged() {
+        // The skip decision is made in the wire's Vec3Q (i16) representation,
+        // so a 0.1-unit jitter that quantizes to the same i16 doesn't trigger
+        // a redundant broadcast — wire bytes wouldn't change anyway.
+        let server = ClusterServer::new(Uuid::new_v4());
+        let id = Uuid::from_u128(1);
+        server.add_entity(entry(id, 5.0));
+        let _ = server.tick();
+
+        server.add_entity(entry(id, 5.1)); // quantizes to 5
+        let delta = server.tick();
+        assert!(
+            delta.updated.is_empty(),
+            "5.0 and 5.1 quantize to the same i16; broadcast must be skipped"
+        );
+    }
+
+    #[test]
+    fn resync_tick_rebroadcasts_unchanged_entities() {
+        // Every Nth tick (default 60 in production; we override to 3 here so
+        // the test is fast), the cluster must broadcast every entity even if
+        // velocity didn't change. Late joiners and packet-loss recovery rely
+        // on this.
+        std::env::set_var("ARCANE_RESYNC_EVERY_N_TICKS", "3");
+        let server = ClusterServer::new(Uuid::new_v4());
+        std::env::remove_var("ARCANE_RESYNC_EVERY_N_TICKS");
+
+        let id = Uuid::from_u128(1);
+        server.add_entity(entry(id, 5.0));
+        // Tick 1: anchor broadcast.
+        assert_eq!(server.tick().updated.len(), 1);
+        // Ticks 2: skipped (velocity unchanged).
+        server.add_entity(entry(id, 5.0));
+        assert_eq!(server.tick().updated.len(), 0);
+        // Tick 3: resync — rebroadcast even though velocity unchanged.
+        server.add_entity(entry(id, 5.0));
+        assert_eq!(server.tick().updated.len(), 1);
+    }
+
+    #[test]
+    fn removed_entity_drops_dead_reckoning_record() {
+        // After an entity is removed, its last-broadcast-velocity record
+        // must be dropped so the map stays bounded by current_entities and
+        // not lifetime-unique-ids-ever-seen. We verify this indirectly: an
+        // entity with the same id rejoining at the same velocity should be
+        // treated as new (first broadcast includes it) — which only happens
+        // if the prior record was forgotten.
+        let server = ClusterServer::new(Uuid::new_v4());
+        let id = Uuid::from_u128(1);
+        server.add_entity(entry(id, 5.0));
+        let _ = server.tick();
+        server.remove_entity(id);
+        let _ = server.tick(); // emits the removal
+
+        // Same entity, same velocity, but treated as a fresh first broadcast.
+        server.add_entity(entry(id, 5.0));
+        let delta = server.tick();
+        assert_eq!(
+            delta.updated.len(),
+            1,
+            "rejoining entity must be broadcast as if new (record was dropped)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #46. Cluster broadcasts only entities whose velocity has changed since their last broadcast (within the wire's i16 quantization step), plus a periodic resync sweep. Clients extrapolate position locally via \`pos(t) = pos_last + vel_last × (t − t_last)\` from the last anchor they received.

## Why

The 6,250-player ceiling at 30 Hz / 200 ms (BENCHMARK_JOURNAL.md 2026-04-26) is bound by cluster outbound NIC: ~1.1 GB/sec sustained per cluster against a c7i.2xlarge sustained-NIC cap near 0.375 GB/sec; \`broadcast_lagged_frames\` hit 10.5M on a single cluster during the run. Quantization (#45) reduced per-entity bytes; this PR attacks the orthogonal axis — number of entities included per broadcast.

## How

- New \`last_broadcast_velocity: Mutex<HashMap<Uuid, Vec3Q>>\` on \`ClusterServer\`.
- On each \`tick()\`, an entity is included in \`delta.updated\` only when:
  - new (no last-broadcast record), OR
  - the current tick is a resync tick (every \`ARCANE_RESYNC_EVERY_N_TICKS\`, default 60), OR
  - the current velocity quantizes to a different \`Vec3Q\` than last time.
- Removed entities drop their dead-reckoning record so the map stays bounded by current entity count.
- Comparison happens in \`Vec3Q\` (i16) not \`Vec3\` (f64) so the skip decision matches the client view exactly.

## Wire format

**Unchanged.** Clients already receive (position, velocity, timestamp) and decode the existing \`DeltaPayload\`. A delta with fewer \`updated\` entries than last tick is already legal — clients hold each entity's last anchor.

## Tests

- 6 new dead-reckoning tests: first-broadcast-includes-everyone, unchanged-skipped, changed-included, sub-quantum-skipped, resync-rebroadcasts-everyone, removed-entity-drops-record.
- Full workspace suite: 107 passed.

## Expected benchmark impact

To be measured. On the \`spread\` deterministic-wander workload (each player holds velocity for many ticks between turns), expected ~70-90% reduction in per-tick broadcast bytes — directly relieving the binding constraint identified in the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)