### PR TITLE
fix(infra): broadcast channel cap default back to 256 (empirically right)

### DIFF
--- a/crates/arcane-infra/src/broadcast_channel_cap.rs
+++ b/crates/arcane-infra/src/broadcast_channel_cap.rs
@@ -29,12 +29,21 @@
 
 const ENV_VAR: &str = "ARCANE_BROADCAST_CHANNEL_CAP";
 
-/// Default buffer cap. Larger than the prior hardcoded 256 because the
-/// 2026-04-27 measurements found 256 was the binding constraint at the
-/// headline 30 Hz / 100 ms tier on commodity hardware. 2048 ≈ 70 sec of
-/// 30 Hz cluster-tick history; chosen to give substantial headroom
-/// without runaway memory growth at typical entity counts.
-const DEFAULT_CAP: usize = 2048;
+/// Default buffer cap. Empirically 256 is the right value for tight
+/// latency gates (≤100 ms): smaller caps force aggressive Lagged
+/// dropping for slow subscribers, which keeps the broadcast pipeline
+/// "hot" for fast subscribers and protects total wall-clock latency.
+/// Bigger caps eliminate Lagged events but let stale broadcasts queue,
+/// which pushes wire latency up at the slowest-subscriber rate.
+///
+/// **Empirical evidence (2026-04-27 journal, Runs G + H):** raising the
+/// default to 2048 *regressed* the published 30 Hz / 100 ms ceiling
+/// from 5,500 → 4,250 (lean) and 4,750 → 4,250 (realistic). Run F at
+/// cap=256 had `broadcast_lagged_frames=342k` and a 4,750 ceiling;
+/// Run H at cap=2048 had zero Lagged events but a lower ceiling.
+/// Operators with relaxed latency budgets (≥200 ms) can raise via the
+/// env override.
+const DEFAULT_CAP: usize = 256;
 
 /// Lower bound. Below this the channel basically can't absorb any
 /// scheduler jitter; tokio's broadcast docs require a positive non-zero


### PR DESCRIPTION
The 2048 default I shipped in #51 was a hypothesis from the diag signal — assumed bigger buffer = fewer Lagged drops = higher ceiling. Empirically wrong.

## Direct measurement (2026-04-27 journal Runs G + H)

| Workload | cap=256 | cap=2048 | Δ |
|---|---|---|---|
| Lean DR @ 30 Hz / 100 ms | **5,500** | 4,250 | **−23%** |
| Realistic DR @ 30 Hz / 100 ms | **4,750** | 4,250 | **−11%** |

## Mechanism

Smaller cap → aggressive \`Lagged\` dropping for slow subscribers → broadcast pipeline stays fresh for fast subscribers → protects total wall-clock latency.

Bigger cap → zero \`Lagged\` events but stale broadcasts queue → wire latency rises at the slowest-subscriber rate. Run H confirmed: \`broadcast_lagged_frames=0\` at cap=2048, but the 100 ms gate fails earlier than at cap=256.

## What stays from #51

The env-var tunability (\`ARCANE_BROADCAST_CHANNEL_CAP\`) is still there. Operators with relaxed-latency budgets (≥200 ms) can raise the cap if their workload benefits from it. This PR just restores the empirically-correct default for the published 30 Hz / 100 ms standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)