### PR TITLE
Use Haiku with Opus advisor; bypass tool-permission prompts

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model haiku --dangerously-skip-permissions"
+          settings: '{"advisorModel": "opus"}'
           prompt: |
             Pick up GitHub issue #${{ github.event.issue.number }} in this repo: "${{ github.event.issue.title }}".
 


### PR DESCRIPTION
Mirror of arcane_swarm#30, validated end-to-end on arcane_swarm#8 → resulting PR arcane_swarm#31 (now merged).

## Changes
- \`claude_args: \"--model haiku --dangerously-skip-permissions\"\` — Haiku as executor; bypass the in-runner tool-permission gate (auto-denies in non-interactive runners and otherwise burns quota looping on retries).
- \`settings: '{\"advisorModel\": \"opus\"}'\` — Opus available to Haiku as in-flight advisor for hard tactical calls.

## Validation
First Sonnet run on arcane_swarm#8: 11 min, \$1.47-equivalent, 38 permission denials, **zero output**. After this fix on arcane_swarm: 3.3 min, \$0.16-equivalent, 0 denials, correct PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)