### PR TITLE
chore: disable claude-code-action workflow — local daemon handles dispatch

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -1,0 +1,12 @@
+name: Claude on labeled issue
+# DISABLED: Local daemon handles worker dispatch. CI would burn Claude Code API quota.
+# Keeping the workflow definition for reference only.
+on:
+  workflow_dispatch:
+
+jobs:
+  claude:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Worker CI disabled — local daemon handles this."


### PR DESCRIPTION
The `anthropics/claude-code-action@v1` workflow fires on `claude-ready` labels and runs workers in the Anthropic cloud, consuming API quota and racing with the local orchestrator daemon. Disabling entirely — the daemon handles all orchestration and worker dispatch locally via the user's own Claude Max plan.

**Change**: changed `on:` triggers to `workflow_dispatch:` only (no automatic triggers) + set job `if: false`.