### PR TITLE
[SMOKE TEST] Add a single-line comment to arcane-core's lib.rs

### DIFF
--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -34,3 +34,5 @@ pub use server_pool::{
 };
 pub use types::{ClusterGeometry, Vec2, Vec3};
 pub use world_simulator::{IWorldSimulator, LastKnownState, SimulatedState, WorldContext};
+
+// daemon-smoke-test: ok


### PR DESCRIPTION
## Quick Summary

- Adds `// daemon-smoke-test: ok` to `crates/arcane-core/src/lib.rs`
- This is a smoke test marker for the arcane-worker pipeline

## Change Type

- feature

## Impact

- No functional impact — single comment line addition
- Risk level: minimal

## Verification

- [x] Build passes (`cargo build`)
- [ ] Tests pass (`cargo test`)
- [x] Formatter clean (`cargo fmt --all -- --check`)

## Decisions made

No decisions worth logging — the spec was unambiguous.

## Reference

- Issue: closes #93
