### PR TITLE
docs(arcane-core): add module-level doc comment (#103)

### DIFF
--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! Arcane Engine — core traits and shared types.
+//! Core types and traits for the Arcane real-time multiplayer engine.
 //!
 //! Defines the stable, I/O-free contracts used by the rest of the workspace.
 //!


### PR DESCRIPTION
## Summary

Replaced the first line of the crate-level doc comment in `arcane-core/src/lib.rs` with the description specified in the issue.

## Change Type

- docs

## Impact

- Developer impact: crate-level doc comment now reads "Core types and traits for the Arcane real-time multiplayer engine."
- Risk level: minimal — doc-only change.

## Verification

- [x] Build passes (`cargo build`)
- [x] Formatter clean (`cargo fmt --all -- --check`)

## Decisions made

_None — work was a literal implementation of the issue spec._

Closes #103
