### PR TITLE
docs(arcane-core): add one-line module-level doc comment to lib.rs

### DIFF
--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -1,18 +1,4 @@
-//! Arcane Engine — core traits and shared types.
-//!
-//! Defines the stable, I/O-free contracts used by the rest of the workspace.
-//!
-//! ## Module responsibilities
-//! - `types`: shared math and geometry primitives (`Vec2`, `Vec3`, `ClusterGeometry`).
-//! - `clustering_model`: merge/split decision interface consumed by manager logic.
-//! - `server_pool`: allocation/release contract for cluster server capacity.
-//! - `replication_channel`: neighbor-delta contract, [`EntityStateEntry`](replication_channel::EntityStateEntry) (four-bucket spine + JSON fields), [`IReplicationChannel`](replication_channel::IReplicationChannel).
-//! - `world_simulator`: contract for unobserved entity state progression.
-//!
-//! ## Interaction model
-//! Implementations in sibling crates (`arcane-rules`, `arcane-pool`, `arcane-infra`) depend on
-//! these contracts. `arcane-core` itself has no runtime side effects and should remain a dependency
-//! root for cross-crate compatibility.
+//! Core types and traits for the Arcane real-time multiplayer engine.
 
 pub mod cluster_simulation;
 pub mod clustering_model;


### PR DESCRIPTION
Closes #103

Add a concise module-level doc comment to `crates/arcane-core/src/lib.rs`:

```rust
//! Core types and traits for the Arcane real-time multiplayer engine.
```