### PR TITLE
[SMOKE] Add module-level doc comment to arcane-core's lib.rs

### DIFF
--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! Arcane Engine — core traits and shared types.
+//! Core types and traits for the Arcane real-time multiplayer engine.
 //!
 //! Defines the stable, I/O-free contracts used by the rest of the workspace.
 //!


### PR DESCRIPTION
Closes #103

Adds the module-level doc comment:
```
//! Core types and traits for the Arcane real-time multiplayer engine.
```

This is the only change made.