### PR TITLE
Epic: Cross-cluster physics — kinematic proxies + imperative-op routing (Refs #127)

### DIFF
--- a/crates/arcane-core/src/cluster_simulation.rs
+++ b/crates/arcane-core/src/cluster_simulation.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::physics_events::{PhysicsEvent, PhysicsEventBatch};
 use crate::replication_channel::EntityStateEntry;
 
 /// A game action sent by a client through the cluster WebSocket. The cluster's
@@ -69,4 +70,16 @@ pub trait ClusterSimulation: Send + Sync {
     /// Advance simulation state by one tick. Called once per tick after client updates and injected
     /// entities are applied, and before the replication delta is built.
     fn on_tick(&self, ctx: &mut ClusterTickContext<'_>);
+
+    /// Apply inbound physics events from neighbor clusters (e.g., routed impulses,
+    /// contact flow-back). Called at the start of the tick, before `on_tick`.
+    /// Default: no-op.
+    fn apply_inbound_physics_events(&self, _events: Vec<PhysicsEventBatch>) {}
+
+    /// Drain any physics events that should be routed to neighbor clusters
+    /// (e.g., impulses applied to proxy entities, contact flow-back).
+    /// Called after `on_tick`. Default: empty.
+    fn drain_routed_physics_ops(&self) -> Vec<(Uuid, PhysicsEvent)> {
+        Vec::new()
+    }
 }

--- a/crates/arcane-core/src/cluster_simulation.rs
+++ b/crates/arcane-core/src/cluster_simulation.rs
@@ -58,6 +58,10 @@ pub struct ClusterTickContext<'a> {
     /// Game actions received from clients this tick. The simulation processes these — the library
     /// does not interpret them. Drained each tick (actions not consumed are discarded).
     pub game_actions: &'a [GameAction],
+    /// Read-only view of entities owned by neighboring clusters.
+    /// Keyed by entity_id. Updated each tick from neighbor replication deltas.
+    /// These entities are NOT owned by this cluster — do not modify them.
+    pub neighbor_entities: &'a HashMap<Uuid, EntityStateEntry>,
 }
 
 /// Custom simulation step for entities owned by this cluster.

--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod cluster_simulation;
 pub mod clustering_model;
+pub mod physics_events;
 pub mod replication_channel;
 pub mod server_pool;
 pub mod types;
@@ -26,6 +27,7 @@ pub use clustering_model::{
     ClusterDecision, ClusterInfo, DecisionReason, DecisionType, IClusteringModel, ModelInfo,
     PlayerInfo, ValidationResult, WorldStateView,
 };
+pub use physics_events::{PhysicsEvent, PhysicsEventBatch, PhysicsOp};
 pub use replication_channel::{
     ChannelConfig, CloseReason, EntityStateDelta, EntityStateEntry, IReplicationChannel,
 };

--- a/crates/arcane-core/src/physics_events.rs
+++ b/crates/arcane-core/src/physics_events.rs
@@ -1,0 +1,55 @@
+//! Cross-cluster physics event types for imperative-op routing (Layer 2).
+//!
+//! When a [`crate::cluster_simulation::ClusterSimulation`] applies an imperative
+//! physics operation (impulse, force, etc.) to a **proxy entity** (owned by a
+//! neighbor cluster), the operation is captured as a [`PhysicsEvent`] and routed
+//! via Redis to the authority cluster for application.
+//!
+//! Contact events between a locally-owned body and a proxy flow back to the
+//! proxy's authority cluster so both sides see the collision.
+
+use uuid::Uuid;
+
+/// A batch of physics events targeting entities on a specific cluster.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct PhysicsEventBatch {
+    pub source_cluster_id: Uuid,
+    pub ops: Vec<PhysicsEvent>,
+}
+
+/// A single physics event targeting one entity.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct PhysicsEvent {
+    pub target_entity_id: Uuid,
+    pub op: PhysicsOp,
+}
+
+/// The physics operation to apply on the authority cluster.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum PhysicsOp {
+    ApplyImpulse {
+        impulse: [f64; 3],
+    },
+    ApplyForce {
+        force: [f64; 3],
+    },
+    ApplyTorqueImpulse {
+        torque: [f64; 3],
+    },
+    SetTranslation {
+        position: [f64; 3],
+    },
+    SetLinvel {
+        linvel: [f64; 3],
+    },
+    SetAngvel {
+        angvel: [f64; 3],
+    },
+    Wake,
+    Sleep,
+    ContactEvent {
+        other_entity_id: Uuid,
+        started: bool,
+    },
+}

--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -8,7 +8,7 @@
 //! - publishes merged state to `ws_server`
 //! - optionally persists snapshots through `spacetimedb_persist`
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -30,6 +30,8 @@ use crate::{ClusterServer, ReplicationChannelManager};
 const LOG_EVERY_TICKS: u64 = 100;
 /// Log parseable server stats every N ticks (for benchmark: entities, clusters, tick_ms).
 const LOG_STATS_EVERY_TICKS: u64 = 40;
+/// Entities not updated by a neighbor for this many ticks are pruned (stale neighbor crash guard).
+const NEIGHBOR_STALE_TICKS: u64 = 300;
 
 /// Cluster-binary environment configuration (CLUSTER_ID, REDIS_URL,
 /// NEIGHBOR_IDS, CLUSTER_WS_PORT). Shared by every cluster-binary entry point
@@ -76,13 +78,18 @@ impl ClusterEnv {
 
 fn merge_with_neighbor_latest(
     our_delta: EntityStateDelta,
-    neighbor_latest: &HashMap<Uuid, Vec<EntityStateEntry>>,
+    neighbor_entities: &HashMap<Uuid, EntityStateEntry>,
 ) -> EntityStateDelta {
+    let local_ids: HashSet<Uuid> = our_delta.updated.iter().map(|e| e.entity_id).collect();
     let merged_updated: Vec<EntityStateEntry> = our_delta
         .updated
-        .iter()
-        .cloned()
-        .chain(neighbor_latest.values().flat_map(|v| v.iter().cloned()))
+        .into_iter()
+        .chain(
+            neighbor_entities
+                .values()
+                .filter(|e| !local_ids.contains(&e.entity_id))
+                .cloned(),
+        )
         .collect();
     EntityStateDelta {
         source_cluster_id: our_delta.source_cluster_id,
@@ -142,7 +149,8 @@ where
 
     let (neighbor_tx, neighbor_rx) = std::sync::mpsc::channel::<EntityStateDelta>();
     spawn_neighbor_subscriber(redis_url.clone(), neighbor_ids.clone(), neighbor_tx);
-    let mut neighbor_latest: HashMap<Uuid, Vec<EntityStateEntry>> = HashMap::new();
+    let mut neighbor_entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+    let mut neighbor_last_seen: HashMap<Uuid, u64> = HashMap::new();
 
     let tick_rate_hz = crate::tick_rate::tick_rate_hz();
     eprintln!(
@@ -169,7 +177,25 @@ where
             server.add_entity(entry);
         }
         while let Ok(delta) = neighbor_rx.try_recv() {
-            neighbor_latest.insert(delta.source_cluster_id, delta.updated);
+            for entry in delta.updated {
+                neighbor_last_seen.insert(entry.entity_id, tick_count);
+                neighbor_entities.insert(entry.entity_id, entry);
+            }
+            for removed_id in &delta.removed {
+                neighbor_entities.remove(removed_id);
+                neighbor_last_seen.remove(removed_id);
+            }
+        }
+        // Prune stale neighbor entities every ~60 ticks to bound memory from crashed neighbors.
+        const PRUNE_INTERVAL_TICKS: u64 = 60;
+        if tick_count.is_multiple_of(PRUNE_INTERVAL_TICKS) {
+            neighbor_last_seen.retain(|id, last_seen| {
+                let keep = tick_count - *last_seen <= NEIGHBOR_STALE_TICKS;
+                if !keep {
+                    neighbor_entities.remove(id);
+                }
+                keep
+            });
         }
         let mut tick_actions: Vec<GameAction> = Vec::new();
         while let Ok(action) = game_actions_rx.try_recv() {
@@ -182,11 +208,12 @@ where
             upcoming_tick,
             simulation.as_ref().map(|s| s.as_ref()),
             &tick_actions,
+            &neighbor_entities,
         );
         let our_delta = server.tick();
         let tick_elapsed = tick_start.elapsed();
         let tick_elapsed_ms = tick_elapsed.as_secs_f64() * 1000.0;
-        let merged_delta = merge_with_neighbor_latest(our_delta, &neighbor_latest);
+        let merged_delta = merge_with_neighbor_latest(our_delta, &neighbor_entities);
         #[cfg(feature = "spacetimedb-persist")]
         if let Some(ref persist) = persist {
             persist.maybe_persist(tick_count, &merged_delta.updated);
@@ -267,9 +294,9 @@ mod tests {
             updated: vec![local_entity.clone()],
             removed: vec![Uuid::from_u128(99)],
         };
-        let mut neighbors = HashMap::new();
-        neighbors.insert(n1, vec![n1_entity.clone()]);
-        neighbors.insert(n2, vec![n2_entity.clone()]);
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        neighbors.insert(n1_entity.entity_id, n1_entity.clone());
+        neighbors.insert(n2_entity.entity_id, n2_entity.clone());
 
         let merged = merge_with_neighbor_latest(our_delta, &neighbors);
         assert_eq!(merged.source_cluster_id, local_cluster);
@@ -295,13 +322,10 @@ mod tests {
     fn merge_uses_latest_neighbor_snapshot_for_each_cluster() {
         let local_cluster = Uuid::from_u128(1);
         let n1 = Uuid::from_u128(2);
-        let old_n1_entity = mk_entry(Uuid::from_u128(21), n1, 1.0);
         let new_n1_entity = mk_entry(Uuid::from_u128(22), n1, 2.0);
 
-        let mut neighbors = HashMap::new();
-        neighbors.insert(n1, vec![old_n1_entity]);
-        // Simulate loop behavior that replaces the last-seen snapshot for a neighbor.
-        neighbors.insert(n1, vec![new_n1_entity.clone()]);
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        neighbors.insert(new_n1_entity.entity_id, new_n1_entity.clone());
 
         let merged = merge_with_neighbor_latest(
             EntityStateDelta {
@@ -316,5 +340,165 @@ mod tests {
         );
         assert_eq!(merged.updated.len(), 1);
         assert_eq!(merged.updated[0].entity_id, new_n1_entity.entity_id);
+    }
+
+    #[test]
+    fn merge_dedup_local_wins_over_neighbor() {
+        let local_cluster = Uuid::from_u128(1);
+        let n1 = Uuid::from_u128(2);
+        let entity_id = Uuid::from_u128(100);
+        let local_entity = mk_entry(entity_id, local_cluster, 10.0);
+        let neighbor_entity = mk_entry(entity_id, n1, 20.0);
+
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        neighbors.insert(entity_id, neighbor_entity);
+
+        let merged = merge_with_neighbor_latest(
+            EntityStateDelta {
+                source_cluster_id: local_cluster,
+                seq: 1,
+                tick: 1,
+                timestamp: 0.0,
+                updated: vec![local_entity.clone()],
+                removed: vec![],
+            },
+            &neighbors,
+        );
+        assert_eq!(
+            merged.updated.len(),
+            1,
+            "dedup must produce exactly one entry"
+        );
+        let entry = &merged.updated[0];
+        assert_eq!(entry.entity_id, entity_id);
+        // Local version wins: position.x should be 10.0, not 20.0
+        assert!(
+            (entry.position.x - 10.0).abs() < 1e-6,
+            "local position must win, got {}",
+            entry.position.x
+        );
+    }
+
+    #[test]
+    fn neighbor_removed_entity_leaves_map() {
+        let entity_id = Uuid::from_u128(200);
+        let entity = mk_entry(entity_id, Uuid::from_u128(2), 15.0);
+        let delta_add = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(2),
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: vec![entity.clone()],
+            removed: vec![],
+        };
+        let delta_remove = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(2),
+            seq: 2,
+            tick: 2,
+            timestamp: 0.0,
+            updated: vec![],
+            removed: vec![entity_id],
+        };
+
+        let mut neighbor_entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbor_last_seen: HashMap<Uuid, u64> = HashMap::new();
+        let mut tick_count: u64 = 0;
+
+        // Apply add delta (simulating the drain loop logic)
+        tick_count += 1;
+        for entry in &delta_add.updated {
+            neighbor_last_seen.insert(entry.entity_id, tick_count);
+            neighbor_entities.insert(entry.entity_id, entry.clone());
+        }
+        assert!(neighbor_entities.contains_key(&entity_id));
+
+        // Apply remove delta
+        tick_count += 1;
+        for removed_id in &delta_remove.removed {
+            neighbor_entities.remove(removed_id);
+            neighbor_last_seen.remove(removed_id);
+        }
+        for entry in &delta_remove.updated {
+            neighbor_last_seen.insert(entry.entity_id, tick_count);
+            neighbor_entities.insert(entry.entity_id, entry.clone());
+        }
+        assert!(!neighbor_entities.contains_key(&entity_id));
+    }
+
+    #[test]
+    fn neighbor_entity_survives_missing_from_later_delta() {
+        let entity_id = Uuid::from_u128(300);
+        let entity = mk_entry(entity_id, Uuid::from_u128(2), 25.0);
+        let delta_1 = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(2),
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: vec![entity.clone()],
+            removed: vec![],
+        };
+        // Delta 2 does NOT mention entity_id (dead reckoning omission)
+        let delta_2 = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(2),
+            seq: 2,
+            tick: 2,
+            timestamp: 0.0,
+            updated: vec![],
+            removed: vec![],
+        };
+
+        let mut neighbor_entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbor_last_seen: HashMap<Uuid, u64> = HashMap::new();
+        let mut tick_count: u64 = 0;
+
+        tick_count += 1;
+        for entry in &delta_1.updated {
+            neighbor_last_seen.insert(entry.entity_id, tick_count);
+            neighbor_entities.insert(entry.entity_id, entry.clone());
+        }
+        assert!(neighbor_entities.contains_key(&entity_id));
+
+        tick_count += 1;
+        for entry in &delta_2.updated {
+            neighbor_last_seen.insert(entry.entity_id, tick_count);
+            neighbor_entities.insert(entry.entity_id, entry.clone());
+        }
+        // Entity must survive — the map persists entries across ticks
+        assert!(neighbor_entities.contains_key(&entity_id));
+    }
+
+    #[test]
+    fn neighbor_entities_accumulate_across_deltas() {
+        let e1 = mk_entry(Uuid::from_u128(401), Uuid::from_u128(2), 1.0);
+        let e2 = mk_entry(Uuid::from_u128(402), Uuid::from_u128(3), 2.0);
+        let delta_1 = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(2),
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: vec![e1.clone()],
+            removed: vec![],
+        };
+        let delta_2 = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(3),
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: vec![e2.clone()],
+            removed: vec![],
+        };
+
+        let mut neighbor_entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbor_last_seen: HashMap<Uuid, u64> = HashMap::new();
+
+        for delta in &[delta_1, delta_2] {
+            for entry in &delta.updated {
+                neighbor_last_seen.insert(entry.entity_id, 1);
+                neighbor_entities.insert(entry.entity_id, entry.clone());
+            }
+        }
+        assert_eq!(neighbor_entities.len(), 2);
+        assert!(neighbor_entities.contains_key(&e1.entity_id));
+        assert!(neighbor_entities.contains_key(&e2.entity_id));
     }
 }

--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 use std::sync::atomic::Ordering;
 
 use arcane_core::cluster_simulation::{ClusterSimulation, GameAction};
+use arcane_core::physics_events::PhysicsEventBatch;
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
@@ -23,6 +24,8 @@ use uuid::Uuid;
 use crate::cluster_stats::{serve_stats_http, ClusterStats};
 #[cfg(feature = "cluster-ws")]
 use crate::neighbor_subscriber::spawn_neighbor_subscriber;
+#[cfg(feature = "cluster-ws")]
+use crate::physics_events_channel::{spawn_physics_events_subscriber, PhysicsEventsPublisher};
 #[cfg(feature = "spacetimedb-persist")]
 use crate::spacetimedb_persist::SpacetimeDbPersist;
 use crate::{ClusterServer, ReplicationChannelManager};
@@ -152,6 +155,11 @@ where
     let mut neighbor_entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
     let mut neighbor_last_seen: HashMap<Uuid, u64> = HashMap::new();
 
+    let (physics_events_tx, physics_events_rx) = std::sync::mpsc::channel::<PhysicsEventBatch>();
+    spawn_physics_events_subscriber(redis_url.clone(), cluster_id, physics_events_tx);
+    let physics_publisher = PhysicsEventsPublisher::new(&redis_url)
+        .map_err(|e| format!("physics events publisher: {}", e))?;
+
     let tick_rate_hz = crate::tick_rate::tick_rate_hz();
     eprintln!(
         "arcane-cluster started cluster_id={} neighbors={} tick_rate={}Hz",
@@ -201,6 +209,17 @@ where
         while let Ok(action) = game_actions_rx.try_recv() {
             tick_actions.push(action);
         }
+        // Drain inbound physics events and deliver to the simulation.
+        let mut inbound_physics: Vec<PhysicsEventBatch> = Vec::new();
+        while let Ok(batch) = physics_events_rx.try_recv() {
+            inbound_physics.push(batch);
+        }
+        if let Some(ref sim) = simulation {
+            if !inbound_physics.is_empty() {
+                sim.apply_inbound_physics_events(inbound_physics);
+            }
+        }
+
         let tick_start = Instant::now();
         let upcoming_tick = server.current_tick() + 1;
         server.simulate_before_tick(
@@ -210,6 +229,17 @@ where
             &tick_actions,
             &neighbor_entities,
         );
+
+        // Drain routed physics ops and publish to neighbor clusters.
+        if let Some(ref sim) = simulation {
+            let routed = sim.drain_routed_physics_ops();
+            if !routed.is_empty() {
+                if let Err(e) = physics_publisher.publish(cluster_id, routed) {
+                    eprintln!("physics events publish error: {}", e);
+                }
+            }
+        }
+
         let our_delta = server.tick();
         let tick_elapsed = tick_start.elapsed();
         let tick_elapsed_ms = tick_elapsed.as_secs_f64() * 1000.0;

--- a/crates/arcane-infra/src/cluster_server.rs
+++ b/crates/arcane-infra/src/cluster_server.rs
@@ -117,6 +117,7 @@ impl ClusterServer {
         upcoming_tick: u64,
         simulation: Option<&dyn ClusterSimulation>,
         game_actions: &[GameAction],
+        neighbor_entities: &HashMap<Uuid, EntityStateEntry>,
     ) {
         let Some(sim) = simulation else {
             return;
@@ -131,6 +132,7 @@ impl ClusterServer {
                 entities: &mut entities,
                 pending_removals: &mut pending_removals,
                 game_actions,
+                neighbor_entities,
             });
         }
         for id in pending_removals {

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -31,6 +31,8 @@ pub mod cluster_runner;
 #[cfg(feature = "cluster-ws")]
 pub mod cluster_stats;
 #[cfg(feature = "cluster-ws")]
+pub mod physics_events_channel;
+#[cfg(feature = "cluster-ws")]
 pub mod ws_server;
 
 #[cfg(feature = "rapier-cluster")]
@@ -38,6 +40,10 @@ pub mod rapier_cluster;
 
 #[cfg(feature = "cluster-ws")]
 pub use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext, GameAction};
+#[cfg(feature = "cluster-ws")]
+pub use arcane_core::physics_events::{PhysicsEvent, PhysicsEventBatch, PhysicsOp};
+#[cfg(feature = "cluster-ws")]
+pub use physics_events_channel::{spawn_physics_events_subscriber, PhysicsEventsPublisher};
 
 pub use cluster_manager::ClusterManager;
 pub use cluster_server::ClusterServer;

--- a/crates/arcane-infra/src/physics_events_channel.rs
+++ b/crates/arcane-infra/src/physics_events_channel.rs
@@ -1,0 +1,148 @@
+//! Redis pub/sub transport for cross-cluster physics events.
+//!
+//! Follows the same pattern as [`crate::neighbor_subscriber`]: thread-spawned
+//! subscriber, JSON over Redis pub/sub, mpsc forwarding.
+//!
+//! Topic: `arcane:physics_events:<cluster_uuid>` (point-to-point — each cluster
+//! subscribes to its own topic).
+
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use arcane_core::physics_events::{PhysicsEvent, PhysicsEventBatch};
+use uuid::Uuid;
+
+/// Publishes physics event batches to target clusters via Redis.
+pub struct PhysicsEventsPublisher {
+    client: redis::Client,
+}
+
+impl PhysicsEventsPublisher {
+    pub fn new(redis_url: &str) -> Result<Self, String> {
+        let client =
+            redis::Client::open(redis_url).map_err(|e| format!("Redis open failed: {}", e))?;
+        Ok(Self { client })
+    }
+
+    /// Group routed ops by target cluster and publish each batch.
+    /// `routed_ops` is `(target_cluster_id, PhysicsEvent)`.
+    pub fn publish(
+        &self,
+        source_cluster_id: Uuid,
+        routed_ops: Vec<(Uuid, PhysicsEvent)>,
+    ) -> Result<(), String> {
+        if routed_ops.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self
+            .client
+            .get_connection()
+            .map_err(|e| format!("Redis connection failed: {}", e))?;
+
+        let mut by_target: std::collections::HashMap<Uuid, Vec<PhysicsEvent>> =
+            std::collections::HashMap::new();
+        for (target, event) in routed_ops {
+            by_target.entry(target).or_default().push(event);
+        }
+
+        for (target_cluster_id, ops) in by_target {
+            let batch = PhysicsEventBatch {
+                source_cluster_id,
+                ops,
+            };
+            let payload = serde_json::to_string(&batch)
+                .map_err(|e| format!("serialize physics batch: {}", e))?;
+            let topic = format!("arcane:physics_events:{}", target_cluster_id);
+            redis::cmd("PUBLISH")
+                .arg(&topic)
+                .arg(&payload)
+                .query::<i64>(&mut conn)
+                .map_err(|e| format!("Redis PUBLISH failed: {}", e))?;
+        }
+        Ok(())
+    }
+}
+
+/// Spawn a background thread subscribing to this cluster's physics events topic.
+pub fn spawn_physics_events_subscriber(
+    redis_url: String,
+    self_cluster_id: Uuid,
+    tx: Sender<PhysicsEventBatch>,
+) {
+    thread::spawn(move || {
+        let client = match redis::Client::open(redis_url.as_str()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("physics events subscriber: Redis open failed: {}", e);
+                return;
+            }
+        };
+        let mut conn = match client.get_connection() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("physics events subscriber: Redis connection failed: {}", e);
+                return;
+            }
+        };
+        let mut pubsub = conn.as_pubsub();
+        let topic = format!("arcane:physics_events:{}", self_cluster_id);
+        if pubsub.subscribe(&topic).is_err() {
+            eprintln!("physics events subscriber: subscribe {} failed", topic);
+            return;
+        }
+        eprintln!("subscribed to physics events topic {}", topic);
+        loop {
+            match pubsub.get_message() {
+                Ok(msg) => {
+                    let payload: String = match msg.get_payload() {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    };
+                    if let Ok(batch) = serde_json::from_str::<PhysicsEventBatch>(&payload) {
+                        let _ = tx.send(batch);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("physics events subscriber: get_message error: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arcane_core::physics_events::PhysicsOp;
+
+    #[test]
+    fn physics_event_batch_json_roundtrip() {
+        let batch = PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(1),
+            ops: vec![
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(10),
+                    op: PhysicsOp::ApplyImpulse {
+                        impulse: [1.0, 2.0, 3.0],
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(11),
+                    op: PhysicsOp::ContactEvent {
+                        other_entity_id: Uuid::from_u128(12),
+                        started: true,
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(13),
+                    op: PhysicsOp::Wake,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&batch).unwrap();
+        let parsed: PhysicsEventBatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.source_cluster_id, batch.source_cluster_id);
+        assert_eq!(parsed.ops.len(), 3);
+    }
+}

--- a/crates/arcane-infra/src/rapier_cluster.rs
+++ b/crates/arcane-infra/src/rapier_cluster.rs
@@ -573,6 +573,9 @@ pub struct RapierClusterTickContext<'a> {
     /// the full surface. Reads and mutations hit Rapier state synchronously
     /// while the user's `on_tick` runs.
     pub physics: PhysicsHandle<'a>,
+    /// Read-only view of entities owned by neighboring clusters.
+    /// These are the entities that have kinematic proxies in the local physics world.
+    pub neighbor_entities: &'a HashMap<Uuid, EntityStateEntry>,
 }
 
 /// Rapier-aware sibling of [`ClusterSimulation`]. Implement this trait and pass
@@ -673,6 +676,9 @@ struct RapierState {
     /// `entity.velocity` → `body.linvel` sync skips these so the imperative
     /// override sticks. Cleared at the start of every tick.
     pending_imperative_linvel: HashSet<Uuid>,
+    /// Entity IDs of kinematic proxy bodies (from neighbor clusters).
+    /// Distinguished from locally-owned bodies in the shared `handles` map.
+    proxy_entities: HashSet<Uuid>,
 }
 
 /// Internal `EventHandler` impl that records collisions into a `Mutex<Vec>`.
@@ -746,6 +752,7 @@ impl RapierState {
             gravity,
             pending_contact_events: Vec::new(),
             pending_imperative_linvel: HashSet::new(),
+            proxy_entities: HashSet::new(),
         }
     }
 
@@ -810,6 +817,61 @@ impl RapierState {
         );
     }
 
+    fn sync_proxies(
+        &mut self,
+        neighbor_entities: &HashMap<Uuid, EntityStateEntry>,
+        owned_entities: &HashMap<Uuid, EntityStateEntry>,
+        rapier_sim: &dyn RapierClusterSimulation,
+        config: &RapierConfig,
+    ) {
+        // Despawn proxies whose entity_id is no longer in neighbor_entities
+        let stale: Vec<Uuid> = self
+            .proxy_entities
+            .iter()
+            .filter(|id| !neighbor_entities.contains_key(id))
+            .copied()
+            .collect();
+        for id in stale {
+            self.despawn(id);
+            self.proxy_entities.remove(&id);
+        }
+
+        // For each neighbor entity, spawn or update the proxy
+        for (entity_id, entry) in neighbor_entities {
+            // Skip if this entity is locally owned (precedence: owned > proxy)
+            if owned_entities.contains_key(entity_id) {
+                // If we had a proxy for it, despawn the proxy
+                if self.proxy_entities.remove(entity_id) {
+                    self.despawn(*entity_id);
+                }
+                continue;
+            }
+
+            if let Some(&handle) = self.handles.get(entity_id) {
+                // Existing proxy — update position
+                if let Some(body) = self.bodies.get_mut(handle) {
+                    body.set_next_kinematic_translation(to_rapier(entry.position));
+                }
+            } else {
+                // New proxy — spawn as KinematicPositionBased
+                let collider_shape = rapier_sim.collider_for(entry, config);
+                let material = rapier_sim.material_for(entry, config);
+                let collision_groups = rapier_sim.collision_groups_for(entry, config);
+                let is_sensor = rapier_sim.is_sensor(entry, config);
+
+                let params = SpawnParams {
+                    shape: collider_shape,
+                    body_kind: RapierBodyKind::KinematicPositionBased,
+                    material,
+                    groups: collision_groups,
+                    is_sensor,
+                };
+                self.spawn(*entity_id, entry, params);
+                self.proxy_entities.insert(*entity_id);
+            }
+        }
+    }
+
     fn step_with_accumulator(&mut self, dt_seconds: f32) {
         self.accumulator += dt_seconds;
         if self.accumulator < FIXED_PHYSICS_DT {
@@ -861,6 +923,10 @@ impl RapierState {
             if skip.contains(id) {
                 continue;
             }
+            // Skip proxies — their positions come from replication, not local physics output
+            if self.proxy_entities.contains(id) {
+                continue;
+            }
             let Some(&handle) = self.handles.get(id) else {
                 continue;
             };
@@ -877,6 +943,7 @@ impl RapierState {
             .handles
             .keys()
             .filter(|id| !entities.contains_key(id))
+            .filter(|id| !self.proxy_entities.contains(id))
             .copied()
             .collect();
         for id in stale {
@@ -1294,6 +1361,7 @@ impl ClusterSimulation for RapierClusterSim {
                         game_actions: ctx.game_actions,
                         contact_events: &prev_contacts,
                         physics,
+                        neighbor_entities: ctx.neighbor_entities,
                     };
                     sim.on_tick(&mut rapier_ctx);
                     // rapier_ctx (and physics) drop here; state is freely usable again.
@@ -1340,6 +1408,16 @@ impl RapierClusterSim {
                 };
                 state.spawn(*id, entry, params);
             }
+        }
+
+        // Sync kinematic proxies for neighbor entities
+        if let Backend::Rapier(ref rapier_sim) = self.backend {
+            state.sync_proxies(
+                ctx.neighbor_entities,
+                ctx.entities,
+                rapier_sim.as_ref(),
+                &self.config,
+            );
         }
 
         state.step_with_accumulator(ctx.dt_seconds as f32);
@@ -3874,5 +3952,356 @@ mod tests {
         // Body should not have moved.
         let p = entities.get(&id).unwrap().position;
         assert!(close(p.x, start.x, 1e-6) && close(p.y, start.y, 1e-6));
+    }
+
+    // ─── kinematic proxy tests ──────────────────────────────────────────────────
+
+    fn step_with_neighbors(
+        sim: &RapierClusterSim,
+        entities: &mut HashMap<Uuid, EntityStateEntry>,
+        neighbors: &HashMap<Uuid, EntityStateEntry>,
+        tick: u64,
+        dt: f64,
+    ) {
+        let mut pending: Vec<Uuid> = Vec::new();
+        let actions: Vec<GameAction> = Vec::new();
+        let mut ctx = ClusterTickContext {
+            cluster_id: Uuid::nil(),
+            tick,
+            dt_seconds: dt,
+            entities,
+            pending_removals: &mut pending,
+            game_actions: &actions,
+            neighbor_entities: neighbors,
+        };
+        sim.on_tick(&mut ctx);
+    }
+
+    struct SimpleSim;
+    impl RapierClusterSimulation for SimpleSim {
+        fn on_tick(&self, _ctx: &mut RapierClusterTickContext<'_>) {}
+    }
+
+    #[test]
+    fn proxy_spawns_as_kinematic_for_neighbor_entity() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbor_id = Uuid::from_u128(1);
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(
+                neighbor_id,
+                Vec3::new(5.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+
+        // Neighbor should have a body in Rapier
+        assert_eq!(handle_count(&sim), 1);
+        // Entity should be in proxy_entities set
+        let state = sim.state.lock().unwrap();
+        assert!(state.proxy_entities.contains(&neighbor_id));
+        // Body should be KinematicPositionBased — verify by checking it doesn't move under gravity
+        drop(state);
+        let neighbors2 = neighbors.clone();
+        for _ in 0..10 {
+            step_with_neighbors(&sim, &mut entities, &neighbors2, 2, CLUSTER_DT);
+        }
+        let p = entities.get(&neighbor_id);
+        // No entity in local entities, so position not in map
+        assert!(p.is_none());
+    }
+
+    #[test]
+    fn proxy_position_tracks_neighbor_entry() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbor_id = Uuid::from_u128(1);
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(
+                neighbor_id,
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+
+        // Change neighbor position
+        let mut neighbors2 = neighbors;
+        neighbors2.get_mut(&neighbor_id).unwrap().position = Vec3::new(5.0, 2.0, 1.0);
+
+        step_with_neighbors(&sim, &mut entities, &neighbors2, 2, CLUSTER_DT);
+
+        // Verify proxy body position matches
+        let state = sim.state.lock().unwrap();
+        if let Some(&handle) = state.handles.get(&neighbor_id) {
+            if let Some(body) = state.bodies.get(handle) {
+                let rapier_pos = body.translation();
+                assert!(close(rapier_pos.x as f64, 5.0, 1e-2));
+                assert!(close(rapier_pos.y as f64, 2.0, 1e-2));
+                assert!(close(rapier_pos.z as f64, 1.0, 1e-2));
+            }
+        } else {
+            panic!("neighbor proxy not found");
+        }
+    }
+
+    #[test]
+    fn proxy_despawns_when_neighbor_removed() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbor_id = Uuid::from_u128(1);
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(
+                neighbor_id,
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+        assert_eq!(handle_count(&sim), 1);
+
+        // Remove from neighbors
+        let neighbors2: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        step_with_neighbors(&sim, &mut entities, &neighbors2, 2, CLUSTER_DT);
+
+        // Body should be gone
+        assert_eq!(handle_count(&sim), 0);
+        let state = sim.state.lock().unwrap();
+        assert!(!state.proxy_entities.contains(&neighbor_id));
+    }
+
+    #[test]
+    fn proxy_does_not_overwrite_entity_map() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbor_id = Uuid::from_u128(1);
+        let proxy_pos = Vec3::new(5.0, 2.0, 1.0);
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(neighbor_id, proxy_pos, Vec3::new(0.0, 0.0, 0.0)),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+
+        // After sync_outputs, ctx.entities should not contain the proxy
+        assert!(!entities.contains_key(&neighbor_id));
+    }
+
+    #[test]
+    fn local_body_collides_with_proxy() {
+        let local_id = Uuid::from_u128(1);
+        let neighbor_id = Uuid::from_u128(2);
+        let events: Arc<Mutex<Vec<ContactEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+
+        struct CollisionCaptureSim {
+            local_id: Uuid,
+            neighbor_id: Uuid,
+            events: Arc<Mutex<Vec<ContactEvent>>>,
+        }
+        impl RapierClusterSimulation for CollisionCaptureSim {
+            fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+                for &event in ctx.contact_events {
+                    if (event.entity_a == self.local_id && event.entity_b == self.neighbor_id)
+                        || (event.entity_a == self.neighbor_id && event.entity_b == self.local_id)
+                    {
+                        self.events.lock().unwrap().push(event);
+                    }
+                }
+            }
+            fn collider_for(
+                &self,
+                _entry: &EntityStateEntry,
+                _config: &RapierConfig,
+            ) -> RapierColliderShape {
+                RapierColliderShape::Ball(1.0)
+            }
+        }
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(CollisionCaptureSim {
+                local_id,
+                neighbor_id,
+                events: events_clone,
+            }),
+            RapierConfig {
+                gravity: [0.0, 0.0, 0.0],
+                ..RapierConfig::default()
+            },
+        );
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(
+                neighbor_id,
+                Vec3::new(1.8, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        // Tick 1: spawn both entities, physics steps, contact emitted post-step
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+        // Tick 2: contact events surfaced to user via on_tick
+        step_with_neighbors(&sim, &mut entities, &neighbors, 2, CLUSTER_DT);
+
+        let captured = events.lock().unwrap();
+        assert!(
+            !captured.is_empty(),
+            "Expected contact event between local and proxy"
+        );
+        assert!(captured[0].started, "Expected Started contact event");
+    }
+
+    #[test]
+    fn owned_entity_takes_precedence_over_proxy() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let entity_id = Uuid::from_u128(1);
+
+        // Same entity_id in both owned and neighbor
+        entities.insert(
+            entity_id,
+            mk_entry(
+                entity_id,
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+        neighbors.insert(
+            entity_id,
+            mk_entry(
+                entity_id,
+                Vec3::new(5.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+
+        // Body should exist (from owned entity)
+        assert_eq!(handle_count(&sim), 1);
+        // Entity should NOT be in proxy_entities
+        let state = sim.state.lock().unwrap();
+        assert!(!state.proxy_entities.contains(&entity_id));
+    }
+
+    #[test]
+    fn raycast_hits_proxy() {
+        let neighbor_id = Uuid::from_u128(1);
+        struct RaycastSim {
+            #[allow(dead_code)]
+            neighbor_id: Uuid,
+            hit_id: Arc<Mutex<Option<Uuid>>>,
+        }
+        impl RapierClusterSimulation for RaycastSim {
+            fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+                if ctx.tick == 2 {
+                    if let Some(hit) = ctx.physics.raycast(
+                        Vec3::new(0.0, 0.0, 0.0),
+                        Vec3::new(1.0, 0.0, 0.0),
+                        10.0,
+                    ) {
+                        *self.hit_id.lock().unwrap() = Some(hit.entity_id);
+                    }
+                }
+            }
+            fn collider_for(
+                &self,
+                _entry: &EntityStateEntry,
+                _config: &RapierConfig,
+            ) -> RapierColliderShape {
+                RapierColliderShape::Ball(1.0)
+            }
+        }
+
+        let hit_id = Arc::new(Mutex::new(None));
+        let hit_id_clone = hit_id.clone();
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(RaycastSim {
+                neighbor_id,
+                hit_id: hit_id_clone,
+            }),
+            RapierConfig::default(),
+        );
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(
+                neighbor_id,
+                Vec3::new(5.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+        step_with_neighbors(&sim, &mut entities, &neighbors, 2, CLUSTER_DT);
+
+        let result = hit_id.lock().unwrap();
+        assert_eq!(*result, Some(neighbor_id));
+    }
+
+    #[test]
+    fn proxy_uses_game_collider_shape() {
+        let neighbor_id = Uuid::from_u128(1);
+        struct CuboidSim {
+            neighbor_id: Uuid,
+        }
+        impl RapierClusterSimulation for CuboidSim {
+            fn on_tick(&self, _ctx: &mut RapierClusterTickContext<'_>) {}
+            fn collider_for(
+                &self,
+                entry: &EntityStateEntry,
+                _config: &RapierConfig,
+            ) -> RapierColliderShape {
+                if entry.entity_id == self.neighbor_id {
+                    RapierColliderShape::Cuboid([2.0, 1.0, 1.0])
+                } else {
+                    RapierColliderShape::Ball(1.0)
+                }
+            }
+        }
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(CuboidSim { neighbor_id }),
+            RapierConfig::default(),
+        );
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(
+                neighbor_id,
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        );
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+
+        // Verify the collider exists and has the right shape
+        // For now, just verify the body exists (detailed shape verification would require more API)
+        assert_eq!(handle_count(&sim), 1);
+        let state = sim.state.lock().unwrap();
+        assert!(state.proxy_entities.contains(&neighbor_id));
     }
 }

--- a/crates/arcane-infra/src/rapier_cluster.rs
+++ b/crates/arcane-infra/src/rapier_cluster.rs
@@ -1370,6 +1370,7 @@ mod tests {
     ) {
         let mut pending: Vec<Uuid> = Vec::new();
         let actions: Vec<GameAction> = Vec::new();
+        let neighbors = HashMap::new();
         let mut ctx = ClusterTickContext {
             cluster_id: Uuid::nil(),
             tick,
@@ -1377,6 +1378,7 @@ mod tests {
             entities,
             pending_removals: &mut pending,
             game_actions: &actions,
+            neighbor_entities: &neighbors,
         };
         sim.on_tick(&mut ctx);
     }
@@ -1815,6 +1817,7 @@ mod tests {
         };
         let actions = vec![action];
         let mut pending: Vec<Uuid> = Vec::new();
+        let neighbors = HashMap::new();
         let mut ctx = ClusterTickContext {
             cluster_id: Uuid::nil(),
             tick: 42,
@@ -1822,6 +1825,7 @@ mod tests {
             entities: &mut entities,
             pending_removals: &mut pending,
             game_actions: &actions,
+            neighbor_entities: &neighbors,
         };
         sim.on_tick(&mut ctx);
 
@@ -2650,6 +2654,7 @@ mod tests {
             },
         ];
         let mut pending: Vec<Uuid> = Vec::new();
+        let neighbors = HashMap::new();
         let mut ctx = ClusterTickContext {
             cluster_id: Uuid::nil(),
             tick: 99,
@@ -2657,6 +2662,7 @@ mod tests {
             entities: &mut entities,
             pending_removals: &mut pending,
             game_actions: &actions,
+            neighbor_entities: &neighbors,
         };
         sim.on_tick(&mut ctx);
 
@@ -2826,6 +2832,7 @@ mod tests {
 
         let actions: Vec<GameAction> = Vec::new();
         let mut pending: Vec<Uuid> = Vec::new();
+        let neighbors = HashMap::new();
         let mut ctx = ClusterTickContext {
             cluster_id: Uuid::nil(),
             tick: 1,
@@ -2833,6 +2840,7 @@ mod tests {
             entities: &mut entities,
             pending_removals: &mut pending,
             game_actions: &actions,
+            neighbor_entities: &neighbors,
         };
         sim_b.on_tick(&mut ctx);
 

--- a/crates/arcane-infra/src/rapier_cluster.rs
+++ b/crates/arcane-infra/src/rapier_cluster.rs
@@ -262,6 +262,7 @@ use rapier3d::prelude::*;
 use uuid::Uuid;
 
 use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
+use arcane_core::physics_events::{PhysicsEvent, PhysicsEventBatch, PhysicsOp};
 use arcane_core::replication_channel::EntityStateEntry;
 use arcane_core::Vec3;
 
@@ -679,6 +680,11 @@ struct RapierState {
     /// Entity IDs of kinematic proxy bodies (from neighbor clusters).
     /// Distinguished from locally-owned bodies in the shared `handles` map.
     proxy_entities: HashSet<Uuid>,
+    /// Entity-pair keys from inbound `ContactEvent` ops this tick.
+    /// Used to suppress flow-back cycles: if we received a contact event for
+    /// (A, B) from a neighbor, we don't re-emit it back when we see the same
+    /// collision in our Rapier step. Cleared at the start of each tick.
+    inbound_contact_keys: HashSet<(Uuid, Uuid)>,
 }
 
 /// Internal `EventHandler` impl that records collisions into a `Mutex<Vec>`.
@@ -753,6 +759,7 @@ impl RapierState {
             pending_contact_events: Vec::new(),
             pending_imperative_linvel: HashSet::new(),
             proxy_entities: HashSet::new(),
+            inbound_contact_keys: HashSet::new(),
         }
     }
 
@@ -950,6 +957,84 @@ impl RapierState {
             self.despawn(id);
         }
     }
+
+    fn apply_inbound_events(&mut self, batches: Vec<PhysicsEventBatch>) {
+        for batch in batches {
+            for event in batch.ops {
+                let entity_id = event.target_entity_id;
+                let Some(&handle) = self.handles.get(&entity_id) else {
+                    continue;
+                };
+                let Some(body) = self.bodies.get_mut(handle) else {
+                    continue;
+                };
+                let is_fixed = body.body_type() == RigidBodyType::Fixed;
+                match event.op {
+                    PhysicsOp::ApplyImpulse { impulse } if !is_fixed => {
+                        body.apply_impulse(
+                            Vector::new(impulse[0] as f32, impulse[1] as f32, impulse[2] as f32),
+                            true,
+                        );
+                        self.pending_imperative_linvel.insert(entity_id);
+                    }
+                    PhysicsOp::ApplyForce { force } if !is_fixed => {
+                        body.add_force(
+                            Vector::new(force[0] as f32, force[1] as f32, force[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::ApplyTorqueImpulse { torque } if !is_fixed => {
+                        body.apply_torque_impulse(
+                            Vector::new(torque[0] as f32, torque[1] as f32, torque[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::SetTranslation { position } => {
+                        body.set_translation(
+                            Vector::new(position[0] as f32, position[1] as f32, position[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::SetLinvel { linvel } if !is_fixed => {
+                        body.set_linvel(
+                            Vector::new(linvel[0] as f32, linvel[1] as f32, linvel[2] as f32),
+                            true,
+                        );
+                        self.pending_imperative_linvel.insert(entity_id);
+                    }
+                    PhysicsOp::SetAngvel { angvel } if !is_fixed => {
+                        body.set_angvel(
+                            Vector::new(angvel[0] as f32, angvel[1] as f32, angvel[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::Wake => {
+                        body.wake_up(true);
+                    }
+                    PhysicsOp::Sleep => {
+                        body.sleep();
+                    }
+                    PhysicsOp::ContactEvent {
+                        other_entity_id,
+                        started,
+                    } => {
+                        let key = if entity_id < other_entity_id {
+                            (entity_id, other_entity_id)
+                        } else {
+                            (other_entity_id, entity_id)
+                        };
+                        self.inbound_contact_keys.insert(key);
+                        self.pending_contact_events.push(ContactEvent {
+                            entity_a: entity_id,
+                            entity_b: other_entity_id,
+                            started,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 }
 
 /// In-tick imperative physics ops, exposed via [`RapierClusterTickContext::physics`].
@@ -978,11 +1063,36 @@ impl RapierState {
 /// imperative override stays in effect for the upcoming physics step.
 pub struct PhysicsHandle<'a> {
     state: &'a mut RapierState,
+    routed_ops: &'a mut Vec<(Uuid, PhysicsEvent)>,
+    neighbor_entities: &'a HashMap<Uuid, EntityStateEntry>,
 }
 
 impl<'a> PhysicsHandle<'a> {
-    fn new(state: &'a mut RapierState) -> Self {
-        Self { state }
+    fn new(
+        state: &'a mut RapierState,
+        routed_ops: &'a mut Vec<(Uuid, PhysicsEvent)>,
+        neighbor_entities: &'a HashMap<Uuid, EntityStateEntry>,
+    ) -> Self {
+        Self {
+            state,
+            routed_ops,
+            neighbor_entities,
+        }
+    }
+
+    fn route_to_authority(&mut self, entity_id: Uuid, op: PhysicsOp) -> bool {
+        if let Some(entry) = self.neighbor_entities.get(&entity_id) {
+            self.routed_ops.push((
+                entry.cluster_id,
+                PhysicsEvent {
+                    target_entity_id: entity_id,
+                    op,
+                },
+            ));
+            true
+        } else {
+            false
+        }
     }
 
     fn body_mut(&mut self, entity_id: Uuid) -> Option<&mut RigidBody> {
@@ -1002,6 +1112,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn apply_impulse(&mut self, entity_id: Uuid, impulse: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::ApplyImpulse {
+                    impulse: [impulse.x, impulse.y, impulse.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1018,6 +1136,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn apply_force(&mut self, entity_id: Uuid, force: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::ApplyForce {
+                    force: [force.x, force.y, force.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1032,6 +1158,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn apply_torque_impulse(&mut self, entity_id: Uuid, torque: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::ApplyTorqueImpulse {
+                    torque: [torque.x, torque.y, torque.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1050,6 +1184,14 @@ impl<'a> PhysicsHandle<'a> {
     /// (you can move walls), though clustering may not yet pin the new
     /// chunk ownership (see clustering-binding epic).
     pub fn set_translation(&mut self, entity_id: Uuid, position: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::SetTranslation {
+                    position: [position.x, position.y, position.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1063,6 +1205,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn set_linvel(&mut self, entity_id: Uuid, linvel: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::SetLinvel {
+                    linvel: [linvel.x, linvel.y, linvel.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1078,6 +1228,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn set_angvel(&mut self, entity_id: Uuid, angvel: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::SetAngvel {
+                    angvel: [angvel.x, angvel.y, angvel.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1100,6 +1258,9 @@ impl<'a> PhysicsHandle<'a> {
 
     /// Wake a sleeping body so it rejoins simulation. Returns `false` if no body.
     pub fn wake(&mut self, entity_id: Uuid) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(entity_id, PhysicsOp::Wake);
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1109,6 +1270,9 @@ impl<'a> PhysicsHandle<'a> {
 
     /// Force a body to sleep. Returns `false` if no body.
     pub fn sleep(&mut self, entity_id: Uuid) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(entity_id, PhysicsOp::Sleep);
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1169,6 +1333,9 @@ impl<'a> PhysicsHandle<'a> {
     /// resulting [`JointId`], or `None` if either entity has no body.
     /// Joints are auto-removed when either entity despawns.
     pub fn create_joint(&mut self, a: Uuid, b: Uuid, joint: JointSpec) -> Option<JointId> {
+        if self.state.proxy_entities.contains(&a) || self.state.proxy_entities.contains(&b) {
+            return None;
+        }
         let h_a = *self.state.handles.get(&a)?;
         let h_b = *self.state.handles.get(&b)?;
         let joint_data: GenericJoint = match joint {
@@ -1249,6 +1416,8 @@ pub struct RapierClusterSim {
     backend: Backend,
     config: RapierConfig,
     state: Mutex<RapierState>,
+    pending_routed_ops: Mutex<Vec<(Uuid, PhysicsEvent)>>,
+    pending_inbound_events: Mutex<Vec<PhysicsEventBatch>>,
 }
 
 impl RapierClusterSim {
@@ -1262,6 +1431,8 @@ impl RapierClusterSim {
             backend,
             config,
             state: Mutex::new(RapierState::new(gravity)),
+            pending_routed_ops: Mutex::new(Vec::new()),
+            pending_inbound_events: Mutex::new(Vec::new()),
         }
     }
 
@@ -1281,6 +1452,8 @@ impl RapierClusterSim {
             backend: Backend::Rapier(rapier_sim),
             config,
             state: Mutex::new(RapierState::new(gravity)),
+            pending_routed_ops: Mutex::new(Vec::new()),
+            pending_inbound_events: Mutex::new(Vec::new()),
         }
     }
 
@@ -1324,34 +1497,42 @@ impl ClusterSimulation for RapierClusterSim {
     fn on_tick(&self, ctx: &mut ClusterTickContext<'_>) {
         match &self.backend {
             Backend::None => {
-                // No user code; lock once and run the physics phase.
                 let mut state = self.state.lock().expect("rapier state lock");
-                // Discard any prior contacts — there is no listener.
                 state.pending_contact_events.clear();
                 state.pending_imperative_linvel.clear();
+                state.inbound_contact_keys.clear();
+                let inbound =
+                    std::mem::take(&mut *self.pending_inbound_events.lock().expect("inbound lock"));
+                state.apply_inbound_events(inbound);
                 self.run_physics_phase(&mut state, ctx);
             }
             Backend::Cluster(sim) => {
-                // Plain ClusterSimulation: lock released during user code
-                // (legacy behavior — plain ClusterSimulation has no PhysicsHandle).
                 {
                     let mut state = self.state.lock().expect("rapier state lock");
-                    // Drop prior contacts — plain ClusterSimulation can't read them.
                     state.pending_contact_events.clear();
                     state.pending_imperative_linvel.clear();
+                    state.inbound_contact_keys.clear();
+                    let inbound = std::mem::take(
+                        &mut *self.pending_inbound_events.lock().expect("inbound lock"),
+                    );
+                    state.apply_inbound_events(inbound);
                 }
                 sim.on_tick(ctx);
                 let mut state = self.state.lock().expect("rapier state lock");
                 self.run_physics_phase(&mut state, ctx);
             }
             Backend::Rapier(sim) => {
-                // Lock held through user `on_tick` so PhysicsHandle can mutate
-                // Rapier state synchronously (impulses, raycasts, joints, etc.).
                 let mut state = self.state.lock().expect("rapier state lock");
                 let prev_contacts = std::mem::take(&mut state.pending_contact_events);
                 state.pending_imperative_linvel.clear();
+                state.inbound_contact_keys.clear();
+                let inbound =
+                    std::mem::take(&mut *self.pending_inbound_events.lock().expect("inbound lock"));
+                state.apply_inbound_events(inbound);
                 {
-                    let physics = PhysicsHandle::new(&mut state);
+                    let mut routed_ops = Vec::new();
+                    let physics =
+                        PhysicsHandle::new(&mut state, &mut routed_ops, ctx.neighbor_entities);
                     let mut rapier_ctx = RapierClusterTickContext {
                         cluster_id: ctx.cluster_id,
                         tick: ctx.tick,
@@ -1364,11 +1545,31 @@ impl ClusterSimulation for RapierClusterSim {
                         neighbor_entities: ctx.neighbor_entities,
                     };
                     sim.on_tick(&mut rapier_ctx);
-                    // rapier_ctx (and physics) drop here; state is freely usable again.
+                    // Drain routed ops from the user's on_tick into the pending buffer.
+                    if !routed_ops.is_empty() {
+                        self.pending_routed_ops
+                            .lock()
+                            .expect("routed ops lock")
+                            .extend(routed_ops);
+                    }
                 }
                 self.run_physics_phase(&mut state, ctx);
             }
         }
+    }
+
+    fn apply_inbound_physics_events(&self, events: Vec<PhysicsEventBatch>) {
+        if events.is_empty() {
+            return;
+        }
+        self.pending_inbound_events
+            .lock()
+            .expect("inbound lock")
+            .extend(events);
+    }
+
+    fn drain_routed_physics_ops(&self) -> Vec<(Uuid, PhysicsEvent)> {
+        std::mem::take(&mut *self.pending_routed_ops.lock().expect("routed ops lock"))
     }
 }
 
@@ -1421,6 +1622,46 @@ impl RapierClusterSim {
         }
 
         state.step_with_accumulator(ctx.dt_seconds as f32);
+
+        // Contact event flow-back: when a collision involves one owned + one proxy
+        // entity, emit a ContactEvent op targeting the proxy's authority cluster.
+        // Skip pairs that arrived as inbound ContactEvents this tick (cycle suppression).
+        for contact in &state.pending_contact_events {
+            let a_proxy = state.proxy_entities.contains(&contact.entity_a);
+            let b_proxy = state.proxy_entities.contains(&contact.entity_b);
+            if !(a_proxy ^ b_proxy) {
+                continue;
+            }
+            let key = if contact.entity_a < contact.entity_b {
+                (contact.entity_a, contact.entity_b)
+            } else {
+                (contact.entity_b, contact.entity_a)
+            };
+            if state.inbound_contact_keys.contains(&key) {
+                continue;
+            }
+            let (proxy_id, owned_id) = if a_proxy {
+                (contact.entity_a, contact.entity_b)
+            } else {
+                (contact.entity_b, contact.entity_a)
+            };
+            if let Some(entry) = ctx.neighbor_entities.get(&proxy_id) {
+                self.pending_routed_ops
+                    .lock()
+                    .expect("routed ops lock")
+                    .push((
+                        entry.cluster_id,
+                        PhysicsEvent {
+                            target_entity_id: proxy_id,
+                            op: PhysicsOp::ContactEvent {
+                                other_entity_id: owned_id,
+                                started: contact.started,
+                            },
+                        },
+                    ));
+            }
+        }
+
         state.sync_outputs(ctx.entities, &removed);
     }
 }
@@ -4303,5 +4544,527 @@ mod tests {
         assert_eq!(handle_count(&sim), 1);
         let state = sim.state.lock().unwrap();
         assert!(state.proxy_entities.contains(&neighbor_id));
+    }
+
+    // ─── Sub-C: cross-cluster physics event routing ─────────────────────────
+
+    fn step_with_neighbors_and_cluster_id(
+        sim: &RapierClusterSim,
+        entities: &mut HashMap<Uuid, EntityStateEntry>,
+        neighbors: &HashMap<Uuid, EntityStateEntry>,
+        tick: u64,
+        dt: f64,
+        cluster_id: Uuid,
+    ) {
+        let mut pending: Vec<Uuid> = Vec::new();
+        let actions: Vec<GameAction> = Vec::new();
+        let mut ctx = ClusterTickContext {
+            cluster_id,
+            tick,
+            dt_seconds: dt,
+            entities,
+            pending_removals: &mut pending,
+            game_actions: &actions,
+            neighbor_entities: neighbors,
+        };
+        sim.on_tick(&mut ctx);
+    }
+
+    struct ImpulseOnProxy {
+        proxy_id: Uuid,
+        impulse: Vec3,
+    }
+    impl RapierClusterSimulation for ImpulseOnProxy {
+        fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+            ctx.physics.apply_impulse(self.proxy_id, self.impulse);
+        }
+    }
+
+    #[test]
+    fn impulse_on_proxy_produces_routed_op() {
+        let proxy_id = Uuid::from_u128(100);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let self_cluster = Uuid::from_u128(1);
+        let impulse = Vec3::new(1.0, 2.0, 3.0);
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(ImpulseOnProxy { proxy_id, impulse }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut entry = mk_entry(proxy_id, Vec3::new(5.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, entry);
+
+        // Tick 1: spawns the proxy body in run_physics_phase
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            self_cluster,
+        );
+        sim.drain_routed_physics_ops(); // discard tick 1 ops
+
+        // Tick 2: user's on_tick applies impulse to the now-existing proxy
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            self_cluster,
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        assert_eq!(routed.len(), 1);
+        assert_eq!(routed[0].0, neighbor_cluster);
+        assert_eq!(routed[0].1.target_entity_id, proxy_id);
+        match &routed[0].1.op {
+            PhysicsOp::ApplyImpulse { impulse: i } => {
+                assert!((i[0] - 1.0).abs() < 1e-6);
+                assert!((i[1] - 2.0).abs() < 1e-6);
+                assert!((i[2] - 3.0).abs() < 1e-6);
+            }
+            _ => panic!("expected ApplyImpulse"),
+        }
+    }
+
+    struct ImpulseOnLocal {
+        local_id: Uuid,
+        impulse: Vec3,
+    }
+    impl RapierClusterSimulation for ImpulseOnLocal {
+        fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+            ctx.physics.apply_impulse(self.local_id, self.impulse);
+        }
+    }
+
+    #[test]
+    fn impulse_on_local_applies_directly_no_routing() {
+        let local_id = Uuid::from_u128(200);
+        let impulse = Vec3::new(0.0, 0.0, 10.0);
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(ImpulseOnLocal { local_id, impulse }),
+            RapierConfig::default(),
+        );
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        // Tick 1: spawns body
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        // Tick 2: on_tick applies impulse to existing body, then physics steps
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        assert!(
+            routed.is_empty(),
+            "local impulse must not produce routed ops"
+        );
+
+        let vel = entities.get(&local_id).unwrap().velocity;
+        assert!(
+            vel.z.abs() > 0.1,
+            "local body should have moved, vel.z={}",
+            vel.z
+        );
+    }
+
+    #[test]
+    fn inbound_event_applies_impulse_to_local_body() {
+        let local_id = Uuid::from_u128(300);
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        // First tick: spawn the body
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+        let vel_before = entities.get(&local_id).unwrap().velocity;
+
+        // Deliver inbound impulse
+        sim.apply_inbound_physics_events(vec![PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(2),
+            ops: vec![PhysicsEvent {
+                target_entity_id: local_id,
+                op: PhysicsOp::ApplyImpulse {
+                    impulse: [0.0, 0.0, 50.0],
+                },
+            }],
+        }]);
+
+        // Second tick: the impulse should be applied
+        step_with_neighbors(&sim, &mut entities, &neighbors, 2, CLUSTER_DT);
+        let vel_after = entities.get(&local_id).unwrap().velocity;
+        assert!(
+            vel_after.z > vel_before.z + 1.0,
+            "inbound impulse should accelerate entity, vel_before.z={}, vel_after.z={}",
+            vel_before.z,
+            vel_after.z,
+        );
+    }
+
+    #[test]
+    fn inbound_event_unknown_entity_is_silently_ignored() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        // Deliver event for non-existent entity — should not panic
+        sim.apply_inbound_physics_events(vec![PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(99),
+            ops: vec![PhysicsEvent {
+                target_entity_id: Uuid::from_u128(999),
+                op: PhysicsOp::ApplyImpulse {
+                    impulse: [1.0, 2.0, 3.0],
+                },
+            }],
+        }]);
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+    }
+
+    #[test]
+    fn contact_between_local_and_proxy_flows_back() {
+        let local_id = Uuid::from_u128(400);
+        let proxy_id = Uuid::from_u128(401);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let self_cluster = Uuid::from_u128(1);
+
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut proxy_entry = mk_entry(
+            proxy_id,
+            Vec3::new(0.0, 0.0, 0.0), // same position = guaranteed overlap
+            Vec3::new(0.0, 0.0, 0.0),
+        );
+        proxy_entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, proxy_entry);
+
+        // Tick 1: spawn both bodies (overlap detected at step)
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            self_cluster,
+        );
+        // Tick 2: contact events from tick 1's step are processed
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            self_cluster,
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        let flowback: Vec<_> = routed
+            .iter()
+            .filter(|(_, e)| matches!(e.op, PhysicsOp::ContactEvent { .. }))
+            .collect();
+        assert!(
+            !flowback.is_empty(),
+            "contact between local and proxy must produce flow-back ContactEvent"
+        );
+        assert_eq!(flowback[0].0, neighbor_cluster);
+    }
+
+    #[test]
+    fn inbound_contact_event_suppresses_flowback_cycle() {
+        let local_id = Uuid::from_u128(500);
+        let proxy_id = Uuid::from_u128(501);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let self_cluster = Uuid::from_u128(1);
+
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut proxy_entry =
+            mk_entry(proxy_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        proxy_entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, proxy_entry);
+
+        // Tick 1: spawn bodies, collision detected, flow-back emitted
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            self_cluster,
+        );
+        // Drain tick 1 flow-back so it doesn't pollute the check
+        let tick1_ops = sim.drain_routed_physics_ops();
+        assert!(
+            tick1_ops
+                .iter()
+                .any(|(_, e)| matches!(e.op, PhysicsOp::ContactEvent { .. })),
+            "tick 1 should produce a flow-back contact for the collision"
+        );
+
+        // Before tick 2: inject an inbound ContactEvent for the same pair
+        sim.apply_inbound_physics_events(vec![PhysicsEventBatch {
+            source_cluster_id: neighbor_cluster,
+            ops: vec![PhysicsEvent {
+                target_entity_id: local_id,
+                op: PhysicsOp::ContactEvent {
+                    other_entity_id: proxy_id,
+                    started: true,
+                },
+            }],
+        }]);
+
+        // Tick 2: flow-back should be suppressed for the inbound contact pair.
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            self_cluster,
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        let flowback_contacts: Vec<_> = routed
+            .iter()
+            .filter(|(_, e)| matches!(e.op, PhysicsOp::ContactEvent { .. }))
+            .collect();
+        assert!(
+            flowback_contacts.is_empty(),
+            "inbound contact event should suppress flow-back for the same pair, got {} ops",
+            flowback_contacts.len()
+        );
+    }
+
+    #[test]
+    fn create_joint_returns_none_when_proxy_involved() {
+        let local_id = Uuid::from_u128(600);
+        let proxy_id = Uuid::from_u128(601);
+        let neighbor_cluster = Uuid::from_u128(2);
+
+        struct JointAttempt {
+            local_id: Uuid,
+            proxy_id: Uuid,
+        }
+        impl RapierClusterSimulation for JointAttempt {
+            fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+                let result = ctx.physics.create_joint(
+                    self.local_id,
+                    self.proxy_id,
+                    JointSpec::Fixed {
+                        local_anchor_a: Vec3::new(0.0, 0.0, 0.0),
+                        local_anchor_b: Vec3::new(0.0, 0.0, 0.0),
+                    },
+                );
+                assert!(result.is_none(), "create_joint on proxy must return None");
+            }
+        }
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(JointAttempt { local_id, proxy_id }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut proxy_entry =
+            mk_entry(proxy_id, Vec3::new(1.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        proxy_entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, proxy_entry);
+
+        // Tick 1: spawn both, proxy spawns as kinematic
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        // Tick 2: user's on_tick tries to create joint — assertion inside
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+    }
+
+    #[test]
+    fn all_write_ops_route_for_proxy() {
+        let proxy_id = Uuid::from_u128(700);
+        let neighbor_cluster = Uuid::from_u128(2);
+
+        struct AllOps {
+            proxy_id: Uuid,
+        }
+        impl RapierClusterSimulation for AllOps {
+            fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+                ctx.physics
+                    .apply_impulse(self.proxy_id, Vec3::new(1.0, 0.0, 0.0));
+                ctx.physics
+                    .apply_force(self.proxy_id, Vec3::new(0.0, 1.0, 0.0));
+                ctx.physics
+                    .apply_torque_impulse(self.proxy_id, Vec3::new(0.0, 0.0, 1.0));
+                ctx.physics
+                    .set_translation(self.proxy_id, Vec3::new(10.0, 0.0, 0.0));
+                ctx.physics
+                    .set_linvel(self.proxy_id, Vec3::new(0.0, 5.0, 0.0));
+                ctx.physics
+                    .set_angvel(self.proxy_id, Vec3::new(0.0, 0.0, 5.0));
+                ctx.physics.wake(self.proxy_id);
+                ctx.physics.sleep(self.proxy_id);
+            }
+        }
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(AllOps { proxy_id }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut entry = mk_entry(proxy_id, Vec3::new(5.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, entry);
+
+        // Tick 1: spawn proxy
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        // Tick 2: on_tick fires all ops
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        assert_eq!(routed.len(), 8, "all 8 write ops should be routed");
+        assert!(routed.iter().all(|(target, _)| *target == neighbor_cluster));
+    }
+
+    #[test]
+    fn physics_event_json_roundtrip() {
+        let batch = PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(1),
+            ops: vec![
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(10),
+                    op: PhysicsOp::ApplyImpulse {
+                        impulse: [1.0, 2.0, 3.0],
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(11),
+                    op: PhysicsOp::ContactEvent {
+                        other_entity_id: Uuid::from_u128(12),
+                        started: true,
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(13),
+                    op: PhysicsOp::Wake,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&batch).unwrap();
+        let parsed: PhysicsEventBatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.source_cluster_id, batch.source_cluster_id);
+        assert_eq!(parsed.ops.len(), 3);
+    }
+
+    #[test]
+    fn drain_routed_ops_is_empty_after_drain() {
+        let proxy_id = Uuid::from_u128(800);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(ImpulseOnProxy {
+                proxy_id,
+                impulse: Vec3::new(1.0, 0.0, 0.0),
+            }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut entry = mk_entry(proxy_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, entry);
+
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+
+        let first = sim.drain_routed_physics_ops();
+        assert!(!first.is_empty());
+        let second = sim.drain_routed_physics_ops();
+        assert!(second.is_empty(), "drain should clear the buffer");
     }
 }

--- a/crates/arcane-infra/src/rapier_cluster.rs
+++ b/crates/arcane-infra/src/rapier_cluster.rs
@@ -107,6 +107,26 @@
 //! precision in the standard `f32` way. If your world exceeds those bounds,
 //! enable Rapier's `f64` feature in a follow-up.
 //!
+//! # Cross-cluster physics
+//!
+//! Entities from neighboring clusters appear as kinematic proxy bodies in the
+//! local Rapier world. Raycasts and collision detection work against them.
+//!
+//! When a `PhysicsHandle` write op (impulse, force, etc.) targets a proxy,
+//! the operation routes via Redis to the authority cluster. Contact events
+//! involving proxies flow back to the authority cluster so both sides observe
+//! the collision.
+//!
+//! Cross-cluster joints are not supported — `create_joint` returns `None`
+//! when either entity is a proxy. Affinity clustering should co-locate
+//! joint participants.
+//!
+//! Authority transfer (entity migration between clusters) is not yet
+//! implemented. It ships with the affinity clustering infrastructure.
+//!
+//! See [`docs/architecture/adr/002-cross-cluster-physics.md`](https://github.com/brainy-bots/arcane/blob/main/docs/architecture/adr/002-cross-cluster-physics.md)
+//! for full design rationale.
+//!
 //! # Example
 //!
 //! ```no_run

--- a/crates/arcane-infra/src/rapier_cluster.rs
+++ b/crates/arcane-infra/src/rapier_cluster.rs
@@ -855,12 +855,13 @@ impl RapierState {
             }
 
             if let Some(&handle) = self.handles.get(entity_id) {
-                // Existing proxy — update position
+                // Existing proxy — snap-correct position and update velocity
                 if let Some(body) = self.bodies.get_mut(handle) {
-                    body.set_next_kinematic_translation(to_rapier(entry.position));
+                    body.set_translation(to_rapier(entry.position), true);
+                    body.set_linvel(to_rapier(entry.velocity), true);
                 }
             } else {
-                // New proxy — spawn as KinematicPositionBased
+                // New proxy — spawn as KinematicVelocityBased
                 let collider_shape = rapier_sim.collider_for(entry, config);
                 let material = rapier_sim.material_for(entry, config);
                 let collision_groups = rapier_sim.collision_groups_for(entry, config);
@@ -868,7 +869,7 @@ impl RapierState {
 
                 let params = SpawnParams {
                     shape: collider_shape,
-                    body_kind: RapierBodyKind::KinematicPositionBased,
+                    body_kind: RapierBodyKind::KinematicVelocityBased,
                     material,
                     groups: collision_groups,
                     is_sensor,
@@ -4245,7 +4246,7 @@ mod tests {
         // Entity should be in proxy_entities set
         let state = sim.state.lock().unwrap();
         assert!(state.proxy_entities.contains(&neighbor_id));
-        // Body should be KinematicPositionBased — verify by checking it doesn't move under gravity
+        // Body should be KinematicVelocityBased — verify by checking it moves with its velocity
         drop(state);
         let neighbors2 = neighbors.clone();
         for _ in 0..10 {
@@ -4279,14 +4280,78 @@ mod tests {
 
         step_with_neighbors(&sim, &mut entities, &neighbors2, 2, CLUSTER_DT);
 
-        // Verify proxy body position matches
+        // Verify proxy body position matches (snap-correction)
         let state = sim.state.lock().unwrap();
         if let Some(&handle) = state.handles.get(&neighbor_id) {
             if let Some(body) = state.bodies.get(handle) {
                 let rapier_pos = body.translation();
-                assert!(close(rapier_pos.x as f64, 5.0, 1e-2));
-                assert!(close(rapier_pos.y as f64, 2.0, 1e-2));
-                assert!(close(rapier_pos.z as f64, 1.0, 1e-2));
+                assert!(
+                    close(rapier_pos.x as f64, 5.0, 1e-2),
+                    "expected x ≈ 5.0, got {}",
+                    rapier_pos.x
+                );
+                assert!(
+                    close(rapier_pos.y as f64, 2.0, 1e-2),
+                    "expected y ≈ 2.0, got {}",
+                    rapier_pos.y
+                );
+                assert!(
+                    close(rapier_pos.z as f64, 1.0, 1e-2),
+                    "expected z ≈ 1.0, got {}",
+                    rapier_pos.z
+                );
+            }
+        } else {
+            panic!("neighbor proxy not found");
+        }
+    }
+
+    #[test]
+    fn proxy_velocity_extrapolates_between_updates() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbor_id = Uuid::from_u128(1);
+        let initial_velocity = Vec3::new(10.0, 0.0, 0.0);
+        neighbors.insert(
+            neighbor_id,
+            mk_entry(neighbor_id, Vec3::new(0.0, 0.0, 0.0), initial_velocity),
+        );
+
+        // Spawn proxy with velocity
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+
+        // Check initial position after spawn
+        {
+            let state = sim.state.lock().unwrap();
+            if let Some(&handle) = state.handles.get(&neighbor_id) {
+                if let Some(body) = state.bodies.get(handle) {
+                    let linvel = body.linvel();
+                    assert!(
+                        close(linvel.x as f64, 10.0, 1e-1),
+                        "initial linvel.x={}, expected ~10",
+                        linvel.x
+                    );
+                }
+            }
+        }
+
+        // Step once more to allow extrapolation
+        let neighbors_unchanged = neighbors.clone();
+        step_with_neighbors(&sim, &mut entities, &neighbors_unchanged, 2, CLUSTER_DT);
+
+        // Verify proxy has moved from the replication delta
+        let state = sim.state.lock().unwrap();
+        if let Some(&handle) = state.handles.get(&neighbor_id) {
+            if let Some(body) = state.bodies.get(handle) {
+                let rapier_pos = body.translation();
+                // With one extra step at CLUSTER_DT, the proxy should move some distance
+                // due to velocity integration in Rapier. At 10 m/s for 0.05s = 0.5m
+                assert!(
+                    close(rapier_pos.x as f64, 0.5, 0.1),
+                    "proxy at x={}, expected ~0.5",
+                    rapier_pos.x
+                );
             }
         } else {
             panic!("neighbor proxy not found");

--- a/crates/arcane-infra/tests/cluster_server_tests.rs
+++ b/crates/arcane-infra/tests/cluster_server_tests.rs
@@ -1,5 +1,6 @@
 //! Tests for ClusterServer (IN-02). Define expected behavior; implementation must satisfy these.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arcane_infra::{ClusterServer, ClusterSimulation, ReplicationChannelManager};
@@ -120,7 +121,7 @@ fn simulate_before_tick_runs_before_delta_and_sees_upcoming_tick() {
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(0.0, 0.0, 0.0),
     ));
-    server.simulate_before_tick(0.05, 1, Some(&RecordTick), &[]);
+    server.simulate_before_tick(0.05, 1, Some(&RecordTick), &[], &HashMap::new());
     let delta = server.tick();
     assert_eq!(delta.tick, 1);
 }
@@ -139,7 +140,7 @@ fn simulate_before_tick_can_mutate_positions() {
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(1.0, 0.0, 0.0),
     ));
-    server.simulate_before_tick(1.0, 1, Some(&NudgePositiveX), &[]);
+    server.simulate_before_tick(1.0, 1, Some(&NudgePositiveX), &[], &HashMap::new());
     let delta = server.tick();
     assert_eq!(delta.updated[0].position.x, 10.0);
 }
@@ -167,7 +168,7 @@ fn simulate_before_tick_pending_removals_end_up_in_delta_removed() {
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(0.0, 0.0, 0.0),
     ));
-    server.simulate_before_tick(0.05, 1, Some(&RemoveAll), &[]);
+    server.simulate_before_tick(0.05, 1, Some(&RemoveAll), &[], &HashMap::new());
     let delta = server.tick();
     assert!(delta.updated.is_empty());
     assert_eq!(delta.removed, vec![entity_id]);
@@ -276,7 +277,7 @@ fn simulate_before_tick_panicking_simulation_poisons_but_does_not_cascade() {
     ));
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        server.simulate_before_tick(0.05, 1, Some(&PanicSim), &[]);
+        server.simulate_before_tick(0.05, 1, Some(&PanicSim), &[], &HashMap::new());
     }));
     assert!(result.is_err(), "panicking simulation should propagate");
     // After a panic, the entities lock is poisoned — tick() will also panic.

--- a/docs/architecture/adr/002-cross-cluster-physics.md
+++ b/docs/architecture/adr/002-cross-cluster-physics.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Status** | Accepted |
 | **Date** | 2026-05-09 |
-| **Implemented in** | PR [`brainy-bots/arcane#128`](https://github.com/brainy-bots/arcane/pull/128) (epic PR); sub-PRs [`#130`](https://github.com/brainy-bots/arcane/pull/130), [`#131`](https://github.com/brainy-bots/arcane/pull/131), [`#132`](https://github.com/brainy-bots/arcane/pull/132) |
+| **Implemented in** | PR [`brainy-bots/arcane#129`](https://github.com/brainy-bots/arcane/pull/129) (epic PR); sub-PRs [`#134`](https://github.com/brainy-bots/arcane/pull/134), [`#136`](https://github.com/brainy-bots/arcane/pull/136), [`#137`](https://github.com/brainy-bots/arcane/pull/137) |
 | **Related epic** | [`#127`](https://github.com/brainy-bots/arcane/issues/127) — Cross-cluster physics interaction |
 | **Related issues** | [`#117`](https://github.com/brainy-bots/arcane/issues/117), [`#120`](https://github.com/brainy-bots/arcane/issues/120), [`#121`](https://github.com/brainy-bots/arcane/issues/121), [`#122`](https://github.com/brainy-bots/arcane/issues/122) |
 
@@ -47,7 +47,7 @@ Entity migration between clusters (the proxy becomes real, the real becomes a pr
 - Joint and contact-state coherence during handoff.
 - Deterministic state snapshot semantics.
 
-This ships with the **affinity clustering infrastructure epic** ([`#135`](https://github.com/brainy-bots/arcane/issues/135) — planned). Until then, entities stay on their original cluster.
+This ships with the **affinity clustering infrastructure epic** ([`#34`](https://github.com/brainy-bots/arcane/issues/34) — planned). Until then, entities stay on their original cluster.
 
 ### Key decisions
 
@@ -84,10 +84,10 @@ cargo build -p arcane-infra --features rapier-cluster
 cargo test -p arcane-infra --features rapier-cluster
 
 # Cross-cluster contact events + raycasts + ops routing
-# (tested in sub-PR #132 — cross-cluster physics integration tests)
+# (tested in sub-PRs #136 and #137)
 ```
 
-The 15 cross-cluster-specific tests in `rapier_cluster::tests::cross_cluster_*` cover:
+The 21 cross-cluster-specific tests in `rapier_cluster::tests` and `physics_events_channel::tests` cover:
 
 - Proxy spawn/despawn (neighbor appears, disappears).
 - Proxy position sync each tick (follows replicated position).
@@ -119,7 +119,7 @@ The 15 cross-cluster-specific tests in `rapier_cluster::tests::cross_cluster_*` 
 
 - [`#119`](https://github.com/brainy-bots/arcane/issues/119) — Terrain epic; terrain colliders already support neighbor reads via `RapierMapProvider`.
 - [`#122`](https://github.com/brainy-bots/arcane/issues/122) — Rapier gap inventory; lists proxy configurability and other capabilities.
-- [`#135`](https://github.com/brainy-bots/arcane/issues/135) — Affinity clustering epic (planned); entity migration + authority transfer as a sub-epic.
+- [`#34`](https://github.com/brainy-bots/arcane/issues/34) — Affinity clustering epic (planned); entity migration + authority transfer as a sub-epic.
 
 ## References
 

--- a/docs/architecture/adr/002-cross-cluster-physics.md
+++ b/docs/architecture/adr/002-cross-cluster-physics.md
@@ -1,0 +1,130 @@
+# ADR-002: Cross-cluster physics interaction — kinematic proxies + imperative-op routing
+
+| | |
+|---|---|
+| **Status** | Accepted |
+| **Date** | 2026-05-09 |
+| **Implemented in** | PR [`brainy-bots/arcane#128`](https://github.com/brainy-bots/arcane/pull/128) (epic PR); sub-PRs [`#130`](https://github.com/brainy-bots/arcane/pull/130), [`#131`](https://github.com/brainy-bots/arcane/pull/131), [`#132`](https://github.com/brainy-bots/arcane/pull/132) |
+| **Related epic** | [`#127`](https://github.com/brainy-bots/arcane/issues/127) — Cross-cluster physics interaction |
+| **Related issues** | [`#117`](https://github.com/brainy-bots/arcane/issues/117), [`#120`](https://github.com/brainy-bots/arcane/issues/120), [`#121`](https://github.com/brainy-bots/arcane/issues/121), [`#122`](https://github.com/brainy-bots/arcane/issues/122) |
+
+## Context
+
+PR #128 delivered single-cluster Rapier physics (documented in ADR-001). Cross-cluster physics is an edge case — affinity clustering actively prevents it by co-locating interacting entities. But it must work for capacity overflow, prediction misses, and relaxed-grouping scenarios (deterministic projectiles).
+
+The decision space had three dimensions:
+
+1. **Proxy representation** — should neighbor entities appear as physics bodies in the local Rapier world, or should we defer all cross-cluster interaction?
+2. **Authority and operations** — when a local entity interacts with a neighbor, who owns the result? Does the local cluster apply force, or does it just read state?
+3. **Phased rollout** — implement all three layers (proxies, imperative ops, authority transfer) at once, or stage them?
+
+## Decision
+
+Implement **Layers 1 and 2** of the three-layer design from issue #127. Layer 3 (authority transfer) defers until entity migration infrastructure exists.
+
+### Layer 1: Kinematic proxies
+
+**Neighbor entities spawn as `KinematicPositionBased` bodies in the local Rapier world.** They participate in raycasts and collision detection but do not move under physics simulation. Their position is synced every tick from the neighbor cluster's replication delta.
+
+- Proxies are created and removed in lockstep with the entity's presence in the local `neighbor_entities` map (populated by `merge_neighbor_updates`).
+- Proxy position follows the replicated `entity.position` each tick — no integration step on the proxy itself.
+- Raycasts against proxies work; they report collisions as if the neighbor entity's collision bounds were present.
+- Contact events involving proxies are stored and surfaced to the game logic the same way as same-cluster contacts (with one-tick delay).
+
+### Layer 2: Imperative-op routing
+
+**Write ops on proxies route via Redis to the authority cluster.** When a `PhysicsHandle` method targets a proxy (e.g., `apply_impulse(neighbor_id, force)`), the operation is JSON-encoded and published to `arcane:physics_events:<target_cluster_uuid>`.
+
+- The authority cluster receives the event, applies the operation to its local copy of the entity, and the result (velocity change, damage, etc.) propagates back through the next replication delta.
+- Operations are **fire-and-forget V1** — same reliability model as entity replication (Redis persistence, no ACK).
+- Inbound ops from other clusters are applied at the start of `run_physics_phase`, after `on_tick` runs but before Rapier steps, ensuring intent is visible to the authoritative physics.
+- **Contact events flow back:** when a proxy participates in a collision, the contact event is stored locally (for the local cluster's game logic) and also published back to the proxy's authority cluster. Both sides see the collision.
+
+### Layer 3 (deferred): Authority transfer
+
+Entity migration between clusters (the proxy becomes real, the real becomes a proxy) requires:
+- Atomic ownership transfer across cluster boundaries.
+- Joint and contact-state coherence during handoff.
+- Deterministic state snapshot semantics.
+
+This ships with the **affinity clustering infrastructure epic** ([`#135`](https://github.com/brainy-bots/arcane/issues/135) — planned). Until then, entities stay on their original cluster.
+
+### Key decisions
+
+- **JSON encoding for physics events** — consistent with entity replication; events are `{entity_id, op_type, op_data}` tuples.
+- **Proxies always `KinematicPositionBased`** — kinematic position-based is the cheapest mode; configurable per-entity proxy kind deferred until a game requests it.
+- **Fire-and-forget V1 reliability** — same as entity replication. A follow-up (when Redis durability proves insufficient for gameplay) will add per-op acks and replay semantics.
+- **Entity_id dedup at merge time** — when merging neighbor deltas, local entities take precedence if both local and neighbor have the same `entity_id`. This shouldn't happen in correctly-implemented affinity, but the rule is deterministic.
+- **Cross-cluster joints return `None`** — `PhysicsHandle::create_joint` returns `None` if either entity is a proxy. Affinity must co-locate joint participants. A future layer (deferred with authority transfer) will lift this.
+- **Per-cluster Redis topic** — ops route to `arcane:physics_events:<target_cluster_uuid>`. The target cluster consumes its own topic, applies ops, and publishes contact events back to the originating cluster.
+
+## Alternatives considered
+
+### A. No proxies — neighbor entities invisible to physics
+
+Rejected. This breaks raycast and intersection queries when entities span cluster boundaries. Scenarios like deterministic projectiles (fired client-side, validated server-side) need cross-cluster raycasts. Manual workarounds (replicate neighbor entities as a separate data structure) duplicate entity replication.
+
+### B. Full authority-transfer at Layer 3 on day one
+
+Rejected. Authority transfer is complex: entity migration mid-tick, joint coherence, atomic state snapshot. Affinity clustering (which prevents most cross-cluster interactions) ships first; authority transfer ships as a separate epic. The two-layer design is stable and useful without it.
+
+### C. Direct `&mut` access to proxy bodies (like same-cluster entities)
+
+Rejected. Proxies are read-only views of remote state. Allowing direct Rapier API calls on proxies would create the false impression that mutations are local; in reality, they must round-trip through Redis. The imperative-op interface (JSON routing) makes the RPC nature explicit.
+
+### D. Synchronous RPC for ops instead of fire-and-forget
+
+Rejected. Same-tick RPC (wait for the authority cluster to apply the op and return the result) would add one-cluster-latency to every cross-cluster op. Fire-and-forget is eventual consistency; if a game needs stricter semantics, it can build on top (bundle ops into a transaction, poll for confirmation via replication).
+
+## Verification
+
+```bash
+# Docs compile and build checks pass
+cargo build -p arcane-infra --features rapier-cluster
+cargo test -p arcane-infra --features rapier-cluster
+
+# Cross-cluster contact events + raycasts + ops routing
+# (tested in sub-PR #132 — cross-cluster physics integration tests)
+```
+
+The 15 cross-cluster-specific tests in `rapier_cluster::tests::cross_cluster_*` cover:
+
+- Proxy spawn/despawn (neighbor appears, disappears).
+- Proxy position sync each tick (follows replicated position).
+- Raycast against proxies (hit detection works).
+- Collision events with proxies (contact surfaced both ways).
+- Imperative ops on proxies (impulse routes to Redis, velocity change visible on authority next tick).
+- Contact event flow-back (contact event published to authority cluster's physics_events topic).
+- Entity_id dedup (local entities shadowed proxies with same ID, if any).
+- Joint creation on proxies returns `None`.
+
+## Consequences
+
+### Positive
+
+- Raycasts and intersection queries now work across cluster boundaries — necessary for client-side prediction (hitscan validation) and deterministic projectiles.
+- Impulses and forces can cross cluster boundaries (with 1-tick latency) — enables physics interactions between entities in different clusters.
+- Contact events are bidirectional — both clusters observe a cross-cluster collision.
+- Defers the hard problem (authority transfer) to a later epic without blocking the common case (affinity prevents most cross-cluster interactions).
+
+### Negative / accepted trade-offs
+
+- **1-tick latency on ops** — a force applied to a proxy takes 1 cluster tick to propagate to the authority and return via replication delta.
+- **Proxies are kinematic only** — no per-entity configurability yet. Affinity-clustered games can live with kinematic proxies; future configurability is tracked in [`#122`](https://github.com/brainy-bots/arcane/issues/122).
+- **Fire-and-forget reliability** — ops can be lost if Redis crashes mid-publish. Affinity clustering (which minimizes cross-cluster interactions) makes this rare. Stricter semantics (transactional ops, acks, replay) are deferred to a follow-up ADR.
+- **No cross-cluster joints yet** — prevents certain physics interactions (ragdolls spanning clusters, rope constraints). Affinity must co-locate joint participants. Deferred to authority-transfer epic.
+- **Entity_id dedup rule** — if affinity is wrong and two clusters claim the same entity, local takes precedence. This is deterministic but silent; it's a symptom of an affinity bug, not a feature. Documented.
+
+### Open follow-ups (tracked elsewhere)
+
+- [`#119`](https://github.com/brainy-bots/arcane/issues/119) — Terrain epic; terrain colliders already support neighbor reads via `RapierMapProvider`.
+- [`#122`](https://github.com/brainy-bots/arcane/issues/122) — Rapier gap inventory; lists proxy configurability and other capabilities.
+- [`#135`](https://github.com/brainy-bots/arcane/issues/135) — Affinity clustering epic (planned); entity migration + authority transfer as a sub-epic.
+
+## References
+
+- [ADR-001](001-rapier-cluster-integration-shape.md) — Rapier cluster integration shape.
+- [`docs/architecture/physics-backends-and-unreal.md`](../physics-backends-and-unreal.md) — Physics-tick contract and multi-backend path; cross-cluster section updated.
+- [`docs/architecture/entity-model.md`](../entity-model.md) — Entity ownership, lifecycle, affinity clustering.
+- [`issue #127`](https://github.com/brainy-bots/arcane/issues/127) — Cross-cluster physics epic (design conversation).
+- [`crates/arcane-infra/src/rapier_cluster.rs`](https://github.com/brainy-bots/arcane/blob/main/crates/arcane-infra/src/rapier_cluster.rs) — Module docs, cross-cluster section.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -11,4 +11,5 @@ Link new ADRs from [physics-backends-and-unreal.md](../physics-backends-and-unre
 | # | Date | Title | Status |
 |---|---|---|---|
 | [001](001-rapier-cluster-integration-shape.md) | 2026-05-03 | Rapier cluster integration shape — composition over inheritance; in-process Rust; entity-keyed user API; spawn-time hooks once per entity | Accepted |
-| 002 | TBD | Unreal cluster integration shape — UE-native dedicated server with Chaos; plugin distribution; UE version pin; networking implementation (C++ native vs FFI shim) | Pending — required by [`#124`](https://github.com/brainy-bots/arcane/issues/124) |
+| [002](002-cross-cluster-physics.md) | 2026-05-09 | Cross-cluster physics interaction — kinematic proxies + imperative-op routing; Layer 1&2 of three-layer design; Layer 3 (authority transfer) deferred until migration infrastructure | Accepted |
+| 003 | TBD | Unreal cluster integration shape — UE-native dedicated server with Chaos; plugin distribution; UE version pin; networking implementation (C++ native vs FFI shim) | Pending — required by [`#124`](https://github.com/brainy-bots/arcane/issues/124) |

--- a/docs/architecture/physics-backends-and-unreal.md
+++ b/docs/architecture/physics-backends-and-unreal.md
@@ -69,7 +69,7 @@ Maintain a **bidirectional map** in the integration layer:
 |---------|----------------|
 | `entity_id` (`Uuid`) | Stable Arcane / wire identity; store as FGuid or string in UE per project convention. |
 | Chaos / Rapier actor / body | Spawn when a new owned entity appears in the authoritative set; destroy when removed or when `pending_removals`-style lifecycle fires. |
-| Neighbor entities | **Policy:** treat as **kinematic** or **pose-only** proxies — do not double-simulate. Full cross-cluster coupling is deferred work (see clustering-binding epic). |
+| Neighbor entities | Appear as **kinematic proxy bodies** in the local Rapier world. Raycasts and collision detection work against them. Write ops on proxies route via `arcane:physics_events:<target_cluster_uuid>` Redis channel to the authority cluster. Contact events flow back bidirectionally. See [ADR-002](adr/002-cross-cluster-physics.md) for full design. Authority transfer (entity migration) deferred to affinity clustering infrastructure. |
 | `user_data` | Optional: stiffness, hitbox id, team — replicated; keep small. |
 | `local_data` | Solver scratch, cooldowns — **not** on Redis wire; see [four-bucket-state-model.md](four-bucket-state-model.md). |
 | **Body kind** | Per-entity, declared at first-sight via `body_kind_for` hook. `Dynamic` (players, projectiles, debris), `KinematicPositionBased` / `KinematicVelocityBased` (server-controlled motion), `Fixed` (walls, placed structures). Default `Dynamic`. See [entity-model.md §4](entity-model.md). |
@@ -92,7 +92,9 @@ The Rapier (Rust) backend has landed and is documented in [ADR-001](adr/001-rapi
 - **Rapier as `optional = true` Cargo dep on `arcane-infra` behind feature `rapier-cluster`.** Vanilla builds pull zero `rapier3d`. No separate crate needed; the feature-flag pattern is sufficient.
 - **Per-engine API discipline:** Rapier-specific types (`RapierColliderShape`, `RapierBodyKind`, `RapierMaterial`) stay in `arcane-infra::rapier_cluster`. They are **not** promoted to engine-neutral `arcane-core` types — see [`entity-model.md` §8](entity-model.md) for why.
 
-The Unreal/Chaos backend will follow the same composition pattern but with engine-native concerns (UE-native types, World Partition integration, Y↔Z axis swap, ×100 unit scale at the wire boundary). [`#124`](https://github.com/brainy-bots/arcane/issues/124) is the implementation epic; ADR-002 (pending) will capture the Unreal-side decisions.
+Cross-cluster physics (neighbor entities as kinematic proxies + imperative-op routing) is documented in [ADR-002](adr/002-cross-cluster-physics.md).
+
+The Unreal/Chaos backend will follow the same composition pattern but with engine-native concerns (UE-native types, World Partition integration, Y↔Z axis swap, ×100 unit scale at the wire boundary). [`#124`](https://github.com/brainy-bots/arcane/issues/124) is the implementation epic; ADR-003 (pending) will capture the Unreal-side decisions.
 
 ---
 


### PR DESCRIPTION
## Quick Summary

- 🟢 **Epic complete.** All 4 sub-issues delivered. Awaiting founder review and merge to `main`.
- **Goal:** Rapier cluster nodes support cross-cluster physics — neighbor entities become kinematic proxies in the local physics world, and imperative ops (impulses, forces) route via Redis to authority clusters.
- **Scope:** Layers 1 and 2 of issue #127. Layer 3 (authority transfer) deferred until affinity clustering and entity migration infrastructure exist.

## Why This Matters

Cross-cluster physics is the graceful-degradation fallback for when affinity clustering can't co-locate interacting entities. Without it, projectiles pass through neighbor entities, explosions stop at cluster boundaries, and raycasts can't hit proxies. This is an edge case by design — affinity clustering actively tries to prevent it — but it must work correctly for capacity overflow and prediction misses.

## Change Type

- feature (epic)

## Scope

**In:**
- Plumb neighbor entities into `ClusterTickContext` (Sub-A)
- Kinematic proxy spawning + lifecycle in `RapierClusterSim` (Sub-B)
- Cross-cluster imperative-op routing via Redis `physics_events` channel (Sub-C)
- Documentation + issue cleanup (Sub-D)

**Out (separate epics / future work):**
- Authority transfer (Layer 3) — depends on affinity clustering + entity migration
- Cross-cluster joints — affinity must co-locate joint participants
- At-least-once delivery — V1 is fire-and-forget
- Genre-specific optimizations (deterministic-projectile fast paths)
- Configurable proxy mode (`KinematicVelocityBased`) — start with `KinematicPositionBased` only

## Architecture Decisions

| Decision | Choice | Rationale |
|---|---|---|
| Message encoding | JSON (serde_json) | Same as existing Redis replication; debuggable |
| Inbound op timing | Start of `run_physics_phase` | Ops participate in that tick's physics step |
| Redis topic | `arcane:physics_events:<target_cluster_uuid>` | Point-to-point; each cluster subscribes to own topic |
| Proxy body kind | `KinematicPositionBased` | Cheapest; solver-skipped, AABB only |
| Tick-ordering dedup | Dedup at merge time | Local `updated` wins over neighbor entries |

## Reference

- **Parent EPIC:** #127 — Cross-cluster physics interaction design
- **Parent of parent:** #8 — Cluster physics backends
- **Builds on:** PR #128 (Rapier single-cluster integration, merged)
- **Downstream:** `brainy-bots/arcane-demos#6` — clustering visualization demo

## Status

| Item | Status |
|------|--------|
| All sub-issues merged | ✅ Done |
| Epic ready for founder review | ✅ Yes |

## Sub-issues

- [x] #130 — Cross-cluster physics Sub-A: plumb neighbor entities into ClusterTickContext (merged — PR #134)
- [x] #131 — Cross-cluster physics Sub-B: kinematic proxy spawning + lifecycle in RapierClusterSim (merged — PR #136)
- [x] #132 — Cross-cluster physics Sub-C: imperative-op routing via Redis + contact event flow-back (merged — PR #137)
- [x] #133 — Cross-cluster physics Sub-D: ADR + docs + issue cleanup (completed — docs via direct commit `b2fe69d` + issue management PR #135; worker attempt PR #138 closed stale-base/redundant)
- [x] #140 — Velocity-based proxy dead reckoning with delta correction (merged — PR #142)

## Action required

**Open blocker on #133:**

> BLOCKER from sub-issue #133: All Sub-D deliverables already present on epic branch (commit b2fe69d):
> - ✅ ADR-002 created at docs/architecture/adr/002-cross-cluster-physics.md
> - ✅ physics-backends-and-unreal.md updated with concrete cross-cluster mechanism
> - ✅ rapier_cluster.rs module doc includes cross-cluster physics section
> - ✅ ADR README index updated to include ADR-002
> - ✅ Issues #117, #120, #121 have been commented with delivery status
> - ✅ Issue #122 inventory updated to show 'Partially delivered' with correct notes
>
> However, there is no Sub-D PR in the workflow yet. PR #138 (which attempted to deliver this work) was closed as failed-attempt due to scope violation (included code changes).
>
> Clarification needed: Should I (1) create a docs-only PR to formally complete Sub-D workflow, or (2) is this issue already considered complete since the work is committed to epic branch? The work itself is done; I'm blocked on understanding the intended workflow state.
> ([comment link](https://github.com/brainy-bots/arcane/pull/129#issuecomment-4411218956))

The orchestrator will resume automatically when the founder responds in this PR's comments.

## Failed attempts

- **PR #138 — docs: cross-cluster physics ADR-002 + issue cleanup (#133)** *(failure mode: stale base / redundant — all files in the diff already existed on `epic/cross-cluster-physics` with identical content; docs committed directly by martinjms at `b2fe69d`, code shipped in Sub-C PR #137; martinjms confirmed on #133: "No further code changes needed for Sub-D")*
  Branch preserved: `feat/issue-133-cross-cluster-physics-sub-d-adr-docs-iss`. See close comment: https://github.com/brainy-bots/arcane/pull/138#issuecomment-4411221011

## Decisions made

### From PR #134 (Sub-A — plumb neighbor entities)

- **Data structure for neighbor accumulation**: Changed from `HashMap<Uuid, Vec<EntityStateEntry>>` (keyed by source cluster) to `HashMap<Uuid, EntityStateEntry>` (keyed by entity_id).
  Reason: Cross-cluster physics cares about *which entity* is where, not *which cluster sent it*. Flattening removes a nesting layer and makes the dedup pass trivial.

- **Stale-entity pruning strategy**: Tracks last-seen tick per entity; prunes every 60 ticks if last update is > 300 ticks old.
  Reason: Avoids unbounded memory growth if a neighbor cluster crashes without notifying. 300 ticks ≈ 5 seconds at 60 Hz.

- **Dedup: local wins over neighbor**: When an entity_id appears in both `our_delta.updated` and `neighbor_entities`, the local version wins.
  Reason: Local cluster is authoritative for its own entities; neighbor entities are read-only. Local wins on transient conflicts.

- **Test-code updates**: All `ClusterTickContext` constructions in `rapier_cluster.rs` tests now pass `&HashMap::new()` for `neighbor_entities`.
  Reason: Plumbing is complete; neighbor logic tested in `cluster_runner.rs` unit tests.

### From PR #136 (Sub-B — kinematic proxy spawning)

- **Always `KinematicPositionBased`; no velocity-based mode yet.** Considered: `KinematicVelocityBased` for smoother interpolation between Redis ticks.
  Reason: configurable proxy mode is out of scope for this sub-issue; `KinematicPositionBased` is the simpler and cheaper default.

- **Two-tick contact surfacing in `local_body_collides_with_proxy` test.** Considered: asserting contact on tick 1.
  Reason: contacts are generated during `step_with_accumulator` and surfaced to `on_tick` on the following tick — consistent with the existing event-pipeline ordering in `RapierClusterSim`.

- **`sync_proxies` placed after owned-entity spawn, before `step_with_accumulator`.** Considered: after the physics step.
  Reason: proxies must exist in the Rapier world before the step so the solver can generate contacts against them in the same tick they're spawned.

- *⚠️ Reviewer note: `proxy_uses_game_collider_shape` does not assert the actual collider shape — it verifies proxy existence and `proxy_entities` membership only. Spec required asserting `collider.shape().as_cuboid()` is `Some`. The per-entity hook is called but the shape change is not verified at runtime. Consider tightening in Sub-D.*

### From PR #137 (Sub-C — imperative-op routing)

- **`PhysicsOp` types in `arcane-core`** (not `arcane-infra`). Considered: define alongside Redis code in `arcane-infra`.
  Reason: avoids cross-feature contamination (`rapier-cluster` vs `cluster-ws`); types are plain serde structs with no Redis or Rapier dependency.

- **`#[non_exhaustive]` on `PhysicsOp`**. Considered: exhaustive enum.
  Reason: forward-compatible for future ops (e.g., `SetGravityScale`); wildcard arm in `apply_inbound_events` handles unknown variants from older senders.

- **Match guards for fixed-body no-ops**. Considered: nested `if` inside match arms.
  Reason: clippy-clean `collapsible_match` resolution — `is_fixed` computed once before the match, used as guard on force/velocity arms.

- **Cycle suppression via `inbound_contact_keys`**. Considered: per-pair dedup in the subscriber.
  Reason: inbound `ContactEvent` ops record a canonical `(min_id, max_id)` key; flow-back loop skips matching pairs. Set cleared per-tick — bounded memory, no drift.

- **`pending_inbound_events` as separate `Mutex`**. Considered: sharing the main state lock.
  Reason: allows `apply_inbound_physics_events` to be called from outside the state lock; runner calls it before `simulate_before_tick`.


### From PR #142 (Sub #140 — velocity-based proxy dead reckoning)

- **Used `set_translation()` for snap-correction, not `set_next_kinematic_translation()`**. Considered: `set_next_kinematic_translation()` (original design).
  Reason: kinematic velocity-based bodies in Rapier require direct position setting; the next-step approach didn't apply position updates in time for tests/collisions.

- **Verify velocity on spawn, not just position**. Considered: only verify position tracking.
  Reason: the whole point of velocity-based proxies is extrapolation; a test confirming velocity integration happens validates the feature end-to-end.

## Decision log (orchestrator comments)

*Running log. See PR comments below for the full sequence.*