### PR TITLE
feat(rapier-cluster): cross-cluster imperative-op routing (Sub-C)

### DIFF
--- a/crates/arcane-core/src/cluster_simulation.rs
+++ b/crates/arcane-core/src/cluster_simulation.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::physics_events::{PhysicsEvent, PhysicsEventBatch};
 use crate::replication_channel::EntityStateEntry;
 
 /// A game action sent by a client through the cluster WebSocket. The cluster's
@@ -69,4 +70,16 @@ pub trait ClusterSimulation: Send + Sync {
     /// Advance simulation state by one tick. Called once per tick after client updates and injected
     /// entities are applied, and before the replication delta is built.
     fn on_tick(&self, ctx: &mut ClusterTickContext<'_>);
+
+    /// Apply inbound physics events from neighbor clusters (e.g., routed impulses,
+    /// contact flow-back). Called at the start of the tick, before `on_tick`.
+    /// Default: no-op.
+    fn apply_inbound_physics_events(&self, _events: Vec<PhysicsEventBatch>) {}
+
+    /// Drain any physics events that should be routed to neighbor clusters
+    /// (e.g., impulses applied to proxy entities, contact flow-back).
+    /// Called after `on_tick`. Default: empty.
+    fn drain_routed_physics_ops(&self) -> Vec<(Uuid, PhysicsEvent)> {
+        Vec::new()
+    }
 }

--- a/crates/arcane-core/src/lib.rs
+++ b/crates/arcane-core/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod cluster_simulation;
 pub mod clustering_model;
+pub mod physics_events;
 pub mod replication_channel;
 pub mod server_pool;
 pub mod types;
@@ -26,6 +27,7 @@ pub use clustering_model::{
     ClusterDecision, ClusterInfo, DecisionReason, DecisionType, IClusteringModel, ModelInfo,
     PlayerInfo, ValidationResult, WorldStateView,
 };
+pub use physics_events::{PhysicsEvent, PhysicsEventBatch, PhysicsOp};
 pub use replication_channel::{
     ChannelConfig, CloseReason, EntityStateDelta, EntityStateEntry, IReplicationChannel,
 };

--- a/crates/arcane-core/src/physics_events.rs
+++ b/crates/arcane-core/src/physics_events.rs
@@ -1,0 +1,55 @@
+//! Cross-cluster physics event types for imperative-op routing (Layer 2).
+//!
+//! When a [`crate::cluster_simulation::ClusterSimulation`] applies an imperative
+//! physics operation (impulse, force, etc.) to a **proxy entity** (owned by a
+//! neighbor cluster), the operation is captured as a [`PhysicsEvent`] and routed
+//! via Redis to the authority cluster for application.
+//!
+//! Contact events between a locally-owned body and a proxy flow back to the
+//! proxy's authority cluster so both sides see the collision.
+
+use uuid::Uuid;
+
+/// A batch of physics events targeting entities on a specific cluster.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct PhysicsEventBatch {
+    pub source_cluster_id: Uuid,
+    pub ops: Vec<PhysicsEvent>,
+}
+
+/// A single physics event targeting one entity.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct PhysicsEvent {
+    pub target_entity_id: Uuid,
+    pub op: PhysicsOp,
+}
+
+/// The physics operation to apply on the authority cluster.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum PhysicsOp {
+    ApplyImpulse {
+        impulse: [f64; 3],
+    },
+    ApplyForce {
+        force: [f64; 3],
+    },
+    ApplyTorqueImpulse {
+        torque: [f64; 3],
+    },
+    SetTranslation {
+        position: [f64; 3],
+    },
+    SetLinvel {
+        linvel: [f64; 3],
+    },
+    SetAngvel {
+        angvel: [f64; 3],
+    },
+    Wake,
+    Sleep,
+    ContactEvent {
+        other_entity_id: Uuid,
+        started: bool,
+    },
+}

--- a/crates/arcane-infra/src/cluster_runner.rs
+++ b/crates/arcane-infra/src/cluster_runner.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 use std::sync::atomic::Ordering;
 
 use arcane_core::cluster_simulation::{ClusterSimulation, GameAction};
+use arcane_core::physics_events::PhysicsEventBatch;
 use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
 use uuid::Uuid;
 
@@ -23,6 +24,8 @@ use uuid::Uuid;
 use crate::cluster_stats::{serve_stats_http, ClusterStats};
 #[cfg(feature = "cluster-ws")]
 use crate::neighbor_subscriber::spawn_neighbor_subscriber;
+#[cfg(feature = "cluster-ws")]
+use crate::physics_events_channel::{spawn_physics_events_subscriber, PhysicsEventsPublisher};
 #[cfg(feature = "spacetimedb-persist")]
 use crate::spacetimedb_persist::SpacetimeDbPersist;
 use crate::{ClusterServer, ReplicationChannelManager};
@@ -152,6 +155,11 @@ where
     let mut neighbor_entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
     let mut neighbor_last_seen: HashMap<Uuid, u64> = HashMap::new();
 
+    let (physics_events_tx, physics_events_rx) = std::sync::mpsc::channel::<PhysicsEventBatch>();
+    spawn_physics_events_subscriber(redis_url.clone(), cluster_id, physics_events_tx);
+    let physics_publisher = PhysicsEventsPublisher::new(&redis_url)
+        .map_err(|e| format!("physics events publisher: {}", e))?;
+
     let tick_rate_hz = crate::tick_rate::tick_rate_hz();
     eprintln!(
         "arcane-cluster started cluster_id={} neighbors={} tick_rate={}Hz",
@@ -201,6 +209,17 @@ where
         while let Ok(action) = game_actions_rx.try_recv() {
             tick_actions.push(action);
         }
+        // Drain inbound physics events and deliver to the simulation.
+        let mut inbound_physics: Vec<PhysicsEventBatch> = Vec::new();
+        while let Ok(batch) = physics_events_rx.try_recv() {
+            inbound_physics.push(batch);
+        }
+        if let Some(ref sim) = simulation {
+            if !inbound_physics.is_empty() {
+                sim.apply_inbound_physics_events(inbound_physics);
+            }
+        }
+
         let tick_start = Instant::now();
         let upcoming_tick = server.current_tick() + 1;
         server.simulate_before_tick(
@@ -210,6 +229,17 @@ where
             &tick_actions,
             &neighbor_entities,
         );
+
+        // Drain routed physics ops and publish to neighbor clusters.
+        if let Some(ref sim) = simulation {
+            let routed = sim.drain_routed_physics_ops();
+            if !routed.is_empty() {
+                if let Err(e) = physics_publisher.publish(cluster_id, routed) {
+                    eprintln!("physics events publish error: {}", e);
+                }
+            }
+        }
+
         let our_delta = server.tick();
         let tick_elapsed = tick_start.elapsed();
         let tick_elapsed_ms = tick_elapsed.as_secs_f64() * 1000.0;

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -31,6 +31,8 @@ pub mod cluster_runner;
 #[cfg(feature = "cluster-ws")]
 pub mod cluster_stats;
 #[cfg(feature = "cluster-ws")]
+pub mod physics_events_channel;
+#[cfg(feature = "cluster-ws")]
 pub mod ws_server;
 
 #[cfg(feature = "rapier-cluster")]
@@ -38,6 +40,10 @@ pub mod rapier_cluster;
 
 #[cfg(feature = "cluster-ws")]
 pub use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext, GameAction};
+#[cfg(feature = "cluster-ws")]
+pub use arcane_core::physics_events::{PhysicsEvent, PhysicsEventBatch, PhysicsOp};
+#[cfg(feature = "cluster-ws")]
+pub use physics_events_channel::{spawn_physics_events_subscriber, PhysicsEventsPublisher};
 
 pub use cluster_manager::ClusterManager;
 pub use cluster_server::ClusterServer;

--- a/crates/arcane-infra/src/physics_events_channel.rs
+++ b/crates/arcane-infra/src/physics_events_channel.rs
@@ -1,0 +1,148 @@
+//! Redis pub/sub transport for cross-cluster physics events.
+//!
+//! Follows the same pattern as [`crate::neighbor_subscriber`]: thread-spawned
+//! subscriber, JSON over Redis pub/sub, mpsc forwarding.
+//!
+//! Topic: `arcane:physics_events:<cluster_uuid>` (point-to-point — each cluster
+//! subscribes to its own topic).
+
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use arcane_core::physics_events::{PhysicsEvent, PhysicsEventBatch};
+use uuid::Uuid;
+
+/// Publishes physics event batches to target clusters via Redis.
+pub struct PhysicsEventsPublisher {
+    client: redis::Client,
+}
+
+impl PhysicsEventsPublisher {
+    pub fn new(redis_url: &str) -> Result<Self, String> {
+        let client =
+            redis::Client::open(redis_url).map_err(|e| format!("Redis open failed: {}", e))?;
+        Ok(Self { client })
+    }
+
+    /// Group routed ops by target cluster and publish each batch.
+    /// `routed_ops` is `(target_cluster_id, PhysicsEvent)`.
+    pub fn publish(
+        &self,
+        source_cluster_id: Uuid,
+        routed_ops: Vec<(Uuid, PhysicsEvent)>,
+    ) -> Result<(), String> {
+        if routed_ops.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self
+            .client
+            .get_connection()
+            .map_err(|e| format!("Redis connection failed: {}", e))?;
+
+        let mut by_target: std::collections::HashMap<Uuid, Vec<PhysicsEvent>> =
+            std::collections::HashMap::new();
+        for (target, event) in routed_ops {
+            by_target.entry(target).or_default().push(event);
+        }
+
+        for (target_cluster_id, ops) in by_target {
+            let batch = PhysicsEventBatch {
+                source_cluster_id,
+                ops,
+            };
+            let payload = serde_json::to_string(&batch)
+                .map_err(|e| format!("serialize physics batch: {}", e))?;
+            let topic = format!("arcane:physics_events:{}", target_cluster_id);
+            redis::cmd("PUBLISH")
+                .arg(&topic)
+                .arg(&payload)
+                .query::<i64>(&mut conn)
+                .map_err(|e| format!("Redis PUBLISH failed: {}", e))?;
+        }
+        Ok(())
+    }
+}
+
+/// Spawn a background thread subscribing to this cluster's physics events topic.
+pub fn spawn_physics_events_subscriber(
+    redis_url: String,
+    self_cluster_id: Uuid,
+    tx: Sender<PhysicsEventBatch>,
+) {
+    thread::spawn(move || {
+        let client = match redis::Client::open(redis_url.as_str()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("physics events subscriber: Redis open failed: {}", e);
+                return;
+            }
+        };
+        let mut conn = match client.get_connection() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("physics events subscriber: Redis connection failed: {}", e);
+                return;
+            }
+        };
+        let mut pubsub = conn.as_pubsub();
+        let topic = format!("arcane:physics_events:{}", self_cluster_id);
+        if pubsub.subscribe(&topic).is_err() {
+            eprintln!("physics events subscriber: subscribe {} failed", topic);
+            return;
+        }
+        eprintln!("subscribed to physics events topic {}", topic);
+        loop {
+            match pubsub.get_message() {
+                Ok(msg) => {
+                    let payload: String = match msg.get_payload() {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    };
+                    if let Ok(batch) = serde_json::from_str::<PhysicsEventBatch>(&payload) {
+                        let _ = tx.send(batch);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("physics events subscriber: get_message error: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arcane_core::physics_events::PhysicsOp;
+
+    #[test]
+    fn physics_event_batch_json_roundtrip() {
+        let batch = PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(1),
+            ops: vec![
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(10),
+                    op: PhysicsOp::ApplyImpulse {
+                        impulse: [1.0, 2.0, 3.0],
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(11),
+                    op: PhysicsOp::ContactEvent {
+                        other_entity_id: Uuid::from_u128(12),
+                        started: true,
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(13),
+                    op: PhysicsOp::Wake,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&batch).unwrap();
+        let parsed: PhysicsEventBatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.source_cluster_id, batch.source_cluster_id);
+        assert_eq!(parsed.ops.len(), 3);
+    }
+}

--- a/crates/arcane-infra/src/rapier_cluster.rs
+++ b/crates/arcane-infra/src/rapier_cluster.rs
@@ -262,6 +262,7 @@ use rapier3d::prelude::*;
 use uuid::Uuid;
 
 use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
+use arcane_core::physics_events::{PhysicsEvent, PhysicsEventBatch, PhysicsOp};
 use arcane_core::replication_channel::EntityStateEntry;
 use arcane_core::Vec3;
 
@@ -679,6 +680,11 @@ struct RapierState {
     /// Entity IDs of kinematic proxy bodies (from neighbor clusters).
     /// Distinguished from locally-owned bodies in the shared `handles` map.
     proxy_entities: HashSet<Uuid>,
+    /// Entity-pair keys from inbound `ContactEvent` ops this tick.
+    /// Used to suppress flow-back cycles: if we received a contact event for
+    /// (A, B) from a neighbor, we don't re-emit it back when we see the same
+    /// collision in our Rapier step. Cleared at the start of each tick.
+    inbound_contact_keys: HashSet<(Uuid, Uuid)>,
 }
 
 /// Internal `EventHandler` impl that records collisions into a `Mutex<Vec>`.
@@ -753,6 +759,7 @@ impl RapierState {
             pending_contact_events: Vec::new(),
             pending_imperative_linvel: HashSet::new(),
             proxy_entities: HashSet::new(),
+            inbound_contact_keys: HashSet::new(),
         }
     }
 
@@ -950,6 +957,84 @@ impl RapierState {
             self.despawn(id);
         }
     }
+
+    fn apply_inbound_events(&mut self, batches: Vec<PhysicsEventBatch>) {
+        for batch in batches {
+            for event in batch.ops {
+                let entity_id = event.target_entity_id;
+                let Some(&handle) = self.handles.get(&entity_id) else {
+                    continue;
+                };
+                let Some(body) = self.bodies.get_mut(handle) else {
+                    continue;
+                };
+                let is_fixed = body.body_type() == RigidBodyType::Fixed;
+                match event.op {
+                    PhysicsOp::ApplyImpulse { impulse } if !is_fixed => {
+                        body.apply_impulse(
+                            Vector::new(impulse[0] as f32, impulse[1] as f32, impulse[2] as f32),
+                            true,
+                        );
+                        self.pending_imperative_linvel.insert(entity_id);
+                    }
+                    PhysicsOp::ApplyForce { force } if !is_fixed => {
+                        body.add_force(
+                            Vector::new(force[0] as f32, force[1] as f32, force[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::ApplyTorqueImpulse { torque } if !is_fixed => {
+                        body.apply_torque_impulse(
+                            Vector::new(torque[0] as f32, torque[1] as f32, torque[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::SetTranslation { position } => {
+                        body.set_translation(
+                            Vector::new(position[0] as f32, position[1] as f32, position[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::SetLinvel { linvel } if !is_fixed => {
+                        body.set_linvel(
+                            Vector::new(linvel[0] as f32, linvel[1] as f32, linvel[2] as f32),
+                            true,
+                        );
+                        self.pending_imperative_linvel.insert(entity_id);
+                    }
+                    PhysicsOp::SetAngvel { angvel } if !is_fixed => {
+                        body.set_angvel(
+                            Vector::new(angvel[0] as f32, angvel[1] as f32, angvel[2] as f32),
+                            true,
+                        );
+                    }
+                    PhysicsOp::Wake => {
+                        body.wake_up(true);
+                    }
+                    PhysicsOp::Sleep => {
+                        body.sleep();
+                    }
+                    PhysicsOp::ContactEvent {
+                        other_entity_id,
+                        started,
+                    } => {
+                        let key = if entity_id < other_entity_id {
+                            (entity_id, other_entity_id)
+                        } else {
+                            (other_entity_id, entity_id)
+                        };
+                        self.inbound_contact_keys.insert(key);
+                        self.pending_contact_events.push(ContactEvent {
+                            entity_a: entity_id,
+                            entity_b: other_entity_id,
+                            started,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 }
 
 /// In-tick imperative physics ops, exposed via [`RapierClusterTickContext::physics`].
@@ -978,11 +1063,36 @@ impl RapierState {
 /// imperative override stays in effect for the upcoming physics step.
 pub struct PhysicsHandle<'a> {
     state: &'a mut RapierState,
+    routed_ops: &'a mut Vec<(Uuid, PhysicsEvent)>,
+    neighbor_entities: &'a HashMap<Uuid, EntityStateEntry>,
 }
 
 impl<'a> PhysicsHandle<'a> {
-    fn new(state: &'a mut RapierState) -> Self {
-        Self { state }
+    fn new(
+        state: &'a mut RapierState,
+        routed_ops: &'a mut Vec<(Uuid, PhysicsEvent)>,
+        neighbor_entities: &'a HashMap<Uuid, EntityStateEntry>,
+    ) -> Self {
+        Self {
+            state,
+            routed_ops,
+            neighbor_entities,
+        }
+    }
+
+    fn route_to_authority(&mut self, entity_id: Uuid, op: PhysicsOp) -> bool {
+        if let Some(entry) = self.neighbor_entities.get(&entity_id) {
+            self.routed_ops.push((
+                entry.cluster_id,
+                PhysicsEvent {
+                    target_entity_id: entity_id,
+                    op,
+                },
+            ));
+            true
+        } else {
+            false
+        }
     }
 
     fn body_mut(&mut self, entity_id: Uuid) -> Option<&mut RigidBody> {
@@ -1002,6 +1112,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn apply_impulse(&mut self, entity_id: Uuid, impulse: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::ApplyImpulse {
+                    impulse: [impulse.x, impulse.y, impulse.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1018,6 +1136,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn apply_force(&mut self, entity_id: Uuid, force: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::ApplyForce {
+                    force: [force.x, force.y, force.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1032,6 +1158,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn apply_torque_impulse(&mut self, entity_id: Uuid, torque: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::ApplyTorqueImpulse {
+                    torque: [torque.x, torque.y, torque.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1050,6 +1184,14 @@ impl<'a> PhysicsHandle<'a> {
     /// (you can move walls), though clustering may not yet pin the new
     /// chunk ownership (see clustering-binding epic).
     pub fn set_translation(&mut self, entity_id: Uuid, position: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::SetTranslation {
+                    position: [position.x, position.y, position.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1063,6 +1205,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn set_linvel(&mut self, entity_id: Uuid, linvel: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::SetLinvel {
+                    linvel: [linvel.x, linvel.y, linvel.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1078,6 +1228,14 @@ impl<'a> PhysicsHandle<'a> {
     ///
     /// Returns `false` if the entity has no body, or the body is `Fixed`.
     pub fn set_angvel(&mut self, entity_id: Uuid, angvel: Vec3) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(
+                entity_id,
+                PhysicsOp::SetAngvel {
+                    angvel: [angvel.x, angvel.y, angvel.z],
+                },
+            );
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1100,6 +1258,9 @@ impl<'a> PhysicsHandle<'a> {
 
     /// Wake a sleeping body so it rejoins simulation. Returns `false` if no body.
     pub fn wake(&mut self, entity_id: Uuid) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(entity_id, PhysicsOp::Wake);
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1109,6 +1270,9 @@ impl<'a> PhysicsHandle<'a> {
 
     /// Force a body to sleep. Returns `false` if no body.
     pub fn sleep(&mut self, entity_id: Uuid) -> bool {
+        if self.state.proxy_entities.contains(&entity_id) {
+            return self.route_to_authority(entity_id, PhysicsOp::Sleep);
+        }
         let Some(body) = self.body_mut(entity_id) else {
             return false;
         };
@@ -1169,6 +1333,9 @@ impl<'a> PhysicsHandle<'a> {
     /// resulting [`JointId`], or `None` if either entity has no body.
     /// Joints are auto-removed when either entity despawns.
     pub fn create_joint(&mut self, a: Uuid, b: Uuid, joint: JointSpec) -> Option<JointId> {
+        if self.state.proxy_entities.contains(&a) || self.state.proxy_entities.contains(&b) {
+            return None;
+        }
         let h_a = *self.state.handles.get(&a)?;
         let h_b = *self.state.handles.get(&b)?;
         let joint_data: GenericJoint = match joint {
@@ -1249,6 +1416,8 @@ pub struct RapierClusterSim {
     backend: Backend,
     config: RapierConfig,
     state: Mutex<RapierState>,
+    pending_routed_ops: Mutex<Vec<(Uuid, PhysicsEvent)>>,
+    pending_inbound_events: Mutex<Vec<PhysicsEventBatch>>,
 }
 
 impl RapierClusterSim {
@@ -1262,6 +1431,8 @@ impl RapierClusterSim {
             backend,
             config,
             state: Mutex::new(RapierState::new(gravity)),
+            pending_routed_ops: Mutex::new(Vec::new()),
+            pending_inbound_events: Mutex::new(Vec::new()),
         }
     }
 
@@ -1281,6 +1452,8 @@ impl RapierClusterSim {
             backend: Backend::Rapier(rapier_sim),
             config,
             state: Mutex::new(RapierState::new(gravity)),
+            pending_routed_ops: Mutex::new(Vec::new()),
+            pending_inbound_events: Mutex::new(Vec::new()),
         }
     }
 
@@ -1324,34 +1497,42 @@ impl ClusterSimulation for RapierClusterSim {
     fn on_tick(&self, ctx: &mut ClusterTickContext<'_>) {
         match &self.backend {
             Backend::None => {
-                // No user code; lock once and run the physics phase.
                 let mut state = self.state.lock().expect("rapier state lock");
-                // Discard any prior contacts — there is no listener.
                 state.pending_contact_events.clear();
                 state.pending_imperative_linvel.clear();
+                state.inbound_contact_keys.clear();
+                let inbound =
+                    std::mem::take(&mut *self.pending_inbound_events.lock().expect("inbound lock"));
+                state.apply_inbound_events(inbound);
                 self.run_physics_phase(&mut state, ctx);
             }
             Backend::Cluster(sim) => {
-                // Plain ClusterSimulation: lock released during user code
-                // (legacy behavior — plain ClusterSimulation has no PhysicsHandle).
                 {
                     let mut state = self.state.lock().expect("rapier state lock");
-                    // Drop prior contacts — plain ClusterSimulation can't read them.
                     state.pending_contact_events.clear();
                     state.pending_imperative_linvel.clear();
+                    state.inbound_contact_keys.clear();
+                    let inbound = std::mem::take(
+                        &mut *self.pending_inbound_events.lock().expect("inbound lock"),
+                    );
+                    state.apply_inbound_events(inbound);
                 }
                 sim.on_tick(ctx);
                 let mut state = self.state.lock().expect("rapier state lock");
                 self.run_physics_phase(&mut state, ctx);
             }
             Backend::Rapier(sim) => {
-                // Lock held through user `on_tick` so PhysicsHandle can mutate
-                // Rapier state synchronously (impulses, raycasts, joints, etc.).
                 let mut state = self.state.lock().expect("rapier state lock");
                 let prev_contacts = std::mem::take(&mut state.pending_contact_events);
                 state.pending_imperative_linvel.clear();
+                state.inbound_contact_keys.clear();
+                let inbound =
+                    std::mem::take(&mut *self.pending_inbound_events.lock().expect("inbound lock"));
+                state.apply_inbound_events(inbound);
                 {
-                    let physics = PhysicsHandle::new(&mut state);
+                    let mut routed_ops = Vec::new();
+                    let physics =
+                        PhysicsHandle::new(&mut state, &mut routed_ops, ctx.neighbor_entities);
                     let mut rapier_ctx = RapierClusterTickContext {
                         cluster_id: ctx.cluster_id,
                         tick: ctx.tick,
@@ -1364,11 +1545,31 @@ impl ClusterSimulation for RapierClusterSim {
                         neighbor_entities: ctx.neighbor_entities,
                     };
                     sim.on_tick(&mut rapier_ctx);
-                    // rapier_ctx (and physics) drop here; state is freely usable again.
+                    // Drain routed ops from the user's on_tick into the pending buffer.
+                    if !routed_ops.is_empty() {
+                        self.pending_routed_ops
+                            .lock()
+                            .expect("routed ops lock")
+                            .extend(routed_ops);
+                    }
                 }
                 self.run_physics_phase(&mut state, ctx);
             }
         }
+    }
+
+    fn apply_inbound_physics_events(&self, events: Vec<PhysicsEventBatch>) {
+        if events.is_empty() {
+            return;
+        }
+        self.pending_inbound_events
+            .lock()
+            .expect("inbound lock")
+            .extend(events);
+    }
+
+    fn drain_routed_physics_ops(&self) -> Vec<(Uuid, PhysicsEvent)> {
+        std::mem::take(&mut *self.pending_routed_ops.lock().expect("routed ops lock"))
     }
 }
 
@@ -1421,6 +1622,46 @@ impl RapierClusterSim {
         }
 
         state.step_with_accumulator(ctx.dt_seconds as f32);
+
+        // Contact event flow-back: when a collision involves one owned + one proxy
+        // entity, emit a ContactEvent op targeting the proxy's authority cluster.
+        // Skip pairs that arrived as inbound ContactEvents this tick (cycle suppression).
+        for contact in &state.pending_contact_events {
+            let a_proxy = state.proxy_entities.contains(&contact.entity_a);
+            let b_proxy = state.proxy_entities.contains(&contact.entity_b);
+            if !(a_proxy ^ b_proxy) {
+                continue;
+            }
+            let key = if contact.entity_a < contact.entity_b {
+                (contact.entity_a, contact.entity_b)
+            } else {
+                (contact.entity_b, contact.entity_a)
+            };
+            if state.inbound_contact_keys.contains(&key) {
+                continue;
+            }
+            let (proxy_id, owned_id) = if a_proxy {
+                (contact.entity_a, contact.entity_b)
+            } else {
+                (contact.entity_b, contact.entity_a)
+            };
+            if let Some(entry) = ctx.neighbor_entities.get(&proxy_id) {
+                self.pending_routed_ops
+                    .lock()
+                    .expect("routed ops lock")
+                    .push((
+                        entry.cluster_id,
+                        PhysicsEvent {
+                            target_entity_id: proxy_id,
+                            op: PhysicsOp::ContactEvent {
+                                other_entity_id: owned_id,
+                                started: contact.started,
+                            },
+                        },
+                    ));
+            }
+        }
+
         state.sync_outputs(ctx.entities, &removed);
     }
 }
@@ -4303,5 +4544,527 @@ mod tests {
         assert_eq!(handle_count(&sim), 1);
         let state = sim.state.lock().unwrap();
         assert!(state.proxy_entities.contains(&neighbor_id));
+    }
+
+    // ─── Sub-C: cross-cluster physics event routing ─────────────────────────
+
+    fn step_with_neighbors_and_cluster_id(
+        sim: &RapierClusterSim,
+        entities: &mut HashMap<Uuid, EntityStateEntry>,
+        neighbors: &HashMap<Uuid, EntityStateEntry>,
+        tick: u64,
+        dt: f64,
+        cluster_id: Uuid,
+    ) {
+        let mut pending: Vec<Uuid> = Vec::new();
+        let actions: Vec<GameAction> = Vec::new();
+        let mut ctx = ClusterTickContext {
+            cluster_id,
+            tick,
+            dt_seconds: dt,
+            entities,
+            pending_removals: &mut pending,
+            game_actions: &actions,
+            neighbor_entities: neighbors,
+        };
+        sim.on_tick(&mut ctx);
+    }
+
+    struct ImpulseOnProxy {
+        proxy_id: Uuid,
+        impulse: Vec3,
+    }
+    impl RapierClusterSimulation for ImpulseOnProxy {
+        fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+            ctx.physics.apply_impulse(self.proxy_id, self.impulse);
+        }
+    }
+
+    #[test]
+    fn impulse_on_proxy_produces_routed_op() {
+        let proxy_id = Uuid::from_u128(100);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let self_cluster = Uuid::from_u128(1);
+        let impulse = Vec3::new(1.0, 2.0, 3.0);
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(ImpulseOnProxy { proxy_id, impulse }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut entry = mk_entry(proxy_id, Vec3::new(5.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, entry);
+
+        // Tick 1: spawns the proxy body in run_physics_phase
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            self_cluster,
+        );
+        sim.drain_routed_physics_ops(); // discard tick 1 ops
+
+        // Tick 2: user's on_tick applies impulse to the now-existing proxy
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            self_cluster,
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        assert_eq!(routed.len(), 1);
+        assert_eq!(routed[0].0, neighbor_cluster);
+        assert_eq!(routed[0].1.target_entity_id, proxy_id);
+        match &routed[0].1.op {
+            PhysicsOp::ApplyImpulse { impulse: i } => {
+                assert!((i[0] - 1.0).abs() < 1e-6);
+                assert!((i[1] - 2.0).abs() < 1e-6);
+                assert!((i[2] - 3.0).abs() < 1e-6);
+            }
+            _ => panic!("expected ApplyImpulse"),
+        }
+    }
+
+    struct ImpulseOnLocal {
+        local_id: Uuid,
+        impulse: Vec3,
+    }
+    impl RapierClusterSimulation for ImpulseOnLocal {
+        fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+            ctx.physics.apply_impulse(self.local_id, self.impulse);
+        }
+    }
+
+    #[test]
+    fn impulse_on_local_applies_directly_no_routing() {
+        let local_id = Uuid::from_u128(200);
+        let impulse = Vec3::new(0.0, 0.0, 10.0);
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(ImpulseOnLocal { local_id, impulse }),
+            RapierConfig::default(),
+        );
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        // Tick 1: spawns body
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        // Tick 2: on_tick applies impulse to existing body, then physics steps
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        assert!(
+            routed.is_empty(),
+            "local impulse must not produce routed ops"
+        );
+
+        let vel = entities.get(&local_id).unwrap().velocity;
+        assert!(
+            vel.z.abs() > 0.1,
+            "local body should have moved, vel.z={}",
+            vel.z
+        );
+    }
+
+    #[test]
+    fn inbound_event_applies_impulse_to_local_body() {
+        let local_id = Uuid::from_u128(300);
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        // First tick: spawn the body
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+        let vel_before = entities.get(&local_id).unwrap().velocity;
+
+        // Deliver inbound impulse
+        sim.apply_inbound_physics_events(vec![PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(2),
+            ops: vec![PhysicsEvent {
+                target_entity_id: local_id,
+                op: PhysicsOp::ApplyImpulse {
+                    impulse: [0.0, 0.0, 50.0],
+                },
+            }],
+        }]);
+
+        // Second tick: the impulse should be applied
+        step_with_neighbors(&sim, &mut entities, &neighbors, 2, CLUSTER_DT);
+        let vel_after = entities.get(&local_id).unwrap().velocity;
+        assert!(
+            vel_after.z > vel_before.z + 1.0,
+            "inbound impulse should accelerate entity, vel_before.z={}, vel_after.z={}",
+            vel_before.z,
+            vel_after.z,
+        );
+    }
+
+    #[test]
+    fn inbound_event_unknown_entity_is_silently_ignored() {
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+
+        // Deliver event for non-existent entity — should not panic
+        sim.apply_inbound_physics_events(vec![PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(99),
+            ops: vec![PhysicsEvent {
+                target_entity_id: Uuid::from_u128(999),
+                op: PhysicsOp::ApplyImpulse {
+                    impulse: [1.0, 2.0, 3.0],
+                },
+            }],
+        }]);
+
+        step_with_neighbors(&sim, &mut entities, &neighbors, 1, CLUSTER_DT);
+    }
+
+    #[test]
+    fn contact_between_local_and_proxy_flows_back() {
+        let local_id = Uuid::from_u128(400);
+        let proxy_id = Uuid::from_u128(401);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let self_cluster = Uuid::from_u128(1);
+
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut proxy_entry = mk_entry(
+            proxy_id,
+            Vec3::new(0.0, 0.0, 0.0), // same position = guaranteed overlap
+            Vec3::new(0.0, 0.0, 0.0),
+        );
+        proxy_entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, proxy_entry);
+
+        // Tick 1: spawn both bodies (overlap detected at step)
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            self_cluster,
+        );
+        // Tick 2: contact events from tick 1's step are processed
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            self_cluster,
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        let flowback: Vec<_> = routed
+            .iter()
+            .filter(|(_, e)| matches!(e.op, PhysicsOp::ContactEvent { .. }))
+            .collect();
+        assert!(
+            !flowback.is_empty(),
+            "contact between local and proxy must produce flow-back ContactEvent"
+        );
+        assert_eq!(flowback[0].0, neighbor_cluster);
+    }
+
+    #[test]
+    fn inbound_contact_event_suppresses_flowback_cycle() {
+        let local_id = Uuid::from_u128(500);
+        let proxy_id = Uuid::from_u128(501);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let self_cluster = Uuid::from_u128(1);
+
+        let sim = RapierClusterSim::with_rapier_sim(Arc::new(SimpleSim), RapierConfig::default());
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut proxy_entry =
+            mk_entry(proxy_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        proxy_entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, proxy_entry);
+
+        // Tick 1: spawn bodies, collision detected, flow-back emitted
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            self_cluster,
+        );
+        // Drain tick 1 flow-back so it doesn't pollute the check
+        let tick1_ops = sim.drain_routed_physics_ops();
+        assert!(
+            tick1_ops
+                .iter()
+                .any(|(_, e)| matches!(e.op, PhysicsOp::ContactEvent { .. })),
+            "tick 1 should produce a flow-back contact for the collision"
+        );
+
+        // Before tick 2: inject an inbound ContactEvent for the same pair
+        sim.apply_inbound_physics_events(vec![PhysicsEventBatch {
+            source_cluster_id: neighbor_cluster,
+            ops: vec![PhysicsEvent {
+                target_entity_id: local_id,
+                op: PhysicsOp::ContactEvent {
+                    other_entity_id: proxy_id,
+                    started: true,
+                },
+            }],
+        }]);
+
+        // Tick 2: flow-back should be suppressed for the inbound contact pair.
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            self_cluster,
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        let flowback_contacts: Vec<_> = routed
+            .iter()
+            .filter(|(_, e)| matches!(e.op, PhysicsOp::ContactEvent { .. }))
+            .collect();
+        assert!(
+            flowback_contacts.is_empty(),
+            "inbound contact event should suppress flow-back for the same pair, got {} ops",
+            flowback_contacts.len()
+        );
+    }
+
+    #[test]
+    fn create_joint_returns_none_when_proxy_involved() {
+        let local_id = Uuid::from_u128(600);
+        let proxy_id = Uuid::from_u128(601);
+        let neighbor_cluster = Uuid::from_u128(2);
+
+        struct JointAttempt {
+            local_id: Uuid,
+            proxy_id: Uuid,
+        }
+        impl RapierClusterSimulation for JointAttempt {
+            fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+                let result = ctx.physics.create_joint(
+                    self.local_id,
+                    self.proxy_id,
+                    JointSpec::Fixed {
+                        local_anchor_a: Vec3::new(0.0, 0.0, 0.0),
+                        local_anchor_b: Vec3::new(0.0, 0.0, 0.0),
+                    },
+                );
+                assert!(result.is_none(), "create_joint on proxy must return None");
+            }
+        }
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(JointAttempt { local_id, proxy_id }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        entities.insert(
+            local_id,
+            mk_entry(local_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0)),
+        );
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut proxy_entry =
+            mk_entry(proxy_id, Vec3::new(1.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        proxy_entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, proxy_entry);
+
+        // Tick 1: spawn both, proxy spawns as kinematic
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        // Tick 2: user's on_tick tries to create joint — assertion inside
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+    }
+
+    #[test]
+    fn all_write_ops_route_for_proxy() {
+        let proxy_id = Uuid::from_u128(700);
+        let neighbor_cluster = Uuid::from_u128(2);
+
+        struct AllOps {
+            proxy_id: Uuid,
+        }
+        impl RapierClusterSimulation for AllOps {
+            fn on_tick(&self, ctx: &mut RapierClusterTickContext<'_>) {
+                ctx.physics
+                    .apply_impulse(self.proxy_id, Vec3::new(1.0, 0.0, 0.0));
+                ctx.physics
+                    .apply_force(self.proxy_id, Vec3::new(0.0, 1.0, 0.0));
+                ctx.physics
+                    .apply_torque_impulse(self.proxy_id, Vec3::new(0.0, 0.0, 1.0));
+                ctx.physics
+                    .set_translation(self.proxy_id, Vec3::new(10.0, 0.0, 0.0));
+                ctx.physics
+                    .set_linvel(self.proxy_id, Vec3::new(0.0, 5.0, 0.0));
+                ctx.physics
+                    .set_angvel(self.proxy_id, Vec3::new(0.0, 0.0, 5.0));
+                ctx.physics.wake(self.proxy_id);
+                ctx.physics.sleep(self.proxy_id);
+            }
+        }
+
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(AllOps { proxy_id }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut entry = mk_entry(proxy_id, Vec3::new(5.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, entry);
+
+        // Tick 1: spawn proxy
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        // Tick 2: on_tick fires all ops
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+
+        let routed = sim.drain_routed_physics_ops();
+        assert_eq!(routed.len(), 8, "all 8 write ops should be routed");
+        assert!(routed.iter().all(|(target, _)| *target == neighbor_cluster));
+    }
+
+    #[test]
+    fn physics_event_json_roundtrip() {
+        let batch = PhysicsEventBatch {
+            source_cluster_id: Uuid::from_u128(1),
+            ops: vec![
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(10),
+                    op: PhysicsOp::ApplyImpulse {
+                        impulse: [1.0, 2.0, 3.0],
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(11),
+                    op: PhysicsOp::ContactEvent {
+                        other_entity_id: Uuid::from_u128(12),
+                        started: true,
+                    },
+                },
+                PhysicsEvent {
+                    target_entity_id: Uuid::from_u128(13),
+                    op: PhysicsOp::Wake,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&batch).unwrap();
+        let parsed: PhysicsEventBatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.source_cluster_id, batch.source_cluster_id);
+        assert_eq!(parsed.ops.len(), 3);
+    }
+
+    #[test]
+    fn drain_routed_ops_is_empty_after_drain() {
+        let proxy_id = Uuid::from_u128(800);
+        let neighbor_cluster = Uuid::from_u128(2);
+        let sim = RapierClusterSim::with_rapier_sim(
+            Arc::new(ImpulseOnProxy {
+                proxy_id,
+                impulse: Vec3::new(1.0, 0.0, 0.0),
+            }),
+            RapierConfig::default(),
+        );
+
+        let mut entities: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut neighbors: HashMap<Uuid, EntityStateEntry> = HashMap::new();
+        let mut entry = mk_entry(proxy_id, Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+        entry.cluster_id = neighbor_cluster;
+        neighbors.insert(proxy_id, entry);
+
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            1,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+        step_with_neighbors_and_cluster_id(
+            &sim,
+            &mut entities,
+            &neighbors,
+            2,
+            CLUSTER_DT,
+            Uuid::from_u128(1),
+        );
+
+        let first = sim.drain_routed_physics_ops();
+        assert!(!first.is_empty());
+        let second = sim.drain_routed_physics_ops();
+        assert!(second.is_empty(), "drain should clear the buffer");
     }
 }


### PR DESCRIPTION
## Summary

- **Layer 2 of cross-cluster physics** (#132, epic #127): imperative physics operations on proxy entities route via Redis `arcane:physics_events:<cluster_uuid>` to the authority cluster for local application.
- All 8 `PhysicsHandle` write ops (impulse, force, torque, set_translation, set_linvel, set_angvel, wake, sleep) check `proxy_entities` **before** `body_mut()` and route to authority via `neighbor_entities.cluster_id` lookup.
- Contact events between owned + proxy entities flow back to the proxy's authority cluster. Cycle suppression via per-tick `inbound_contact_keys` prevents infinite ping-pong.
- `create_joint` returns `None` when either entity is a proxy (affinity clustering should co-locate joint participants).
- New types in `arcane-core`: `PhysicsEventBatch`, `PhysicsEvent`, `PhysicsOp` (plain serde structs, no Redis dependency).
- New `ClusterSimulation` trait methods with default no-ops: `apply_inbound_physics_events`, `drain_routed_physics_ops`.
- New `physics_events_channel.rs`: Redis pub/sub publisher + subscriber following `neighbor_subscriber.rs` pattern.
- `cluster_runner.rs` wired with subscriber (spawned at startup) + publisher (drains per-tick).

## Changed files

| File | What |
|---|---|
| `arcane-core/src/physics_events.rs` | **New** — `PhysicsEventBatch`, `PhysicsEvent`, `PhysicsOp` types |
| `arcane-core/src/cluster_simulation.rs` | 2 default trait methods on `ClusterSimulation` |
| `arcane-core/src/lib.rs` | Module + re-exports |
| `arcane-infra/src/physics_events_channel.rs` | **New** — Redis pub/sub for physics events |
| `arcane-infra/src/rapier_cluster.rs` | Proxy routing in `PhysicsHandle`, inbound application in `RapierState`, contact flow-back + cycle suppression, `pending_routed_ops`/`pending_inbound_events` on `RapierClusterSim` |
| `arcane-infra/src/cluster_runner.rs` | Subscriber/publisher setup + per-tick drain/publish wiring |
| `arcane-infra/src/lib.rs` | Module + re-exports |

## Design decisions

- **`PhysicsOp` in `arcane-core`** (not `arcane-infra`): avoids cross-feature contamination (`rapier-cluster` vs `cluster-ws`). The types are plain serde structs with no Redis or Rapier dependency.
- **`#[non_exhaustive]` on `PhysicsOp`**: forward-compatible for future ops (e.g., `SetGravityScale`). Wildcard arm in `apply_inbound_events` handles unknown variants.
- **Match guards for Fixed-body no-ops**: clippy-clean `collapsible_match` resolution — `is_fixed` computed once before the match, used as guard on force/velocity arms.
- **Cycle suppression**: inbound `ContactEvent` ops record a canonical `(min_id, max_id)` key in `inbound_contact_keys`. The flow-back loop skips pairs matching any inbound key. Set is cleared per-tick.
- **`pending_inbound_events` as separate Mutex**: allows `apply_inbound_physics_events` to be called from outside the state lock (the cluster runner calls it before `simulate_before_tick`).

## Test plan

- [x] `impulse_on_proxy_produces_routed_op` — impulse on proxy captures routed op with correct target cluster + payload
- [x] `impulse_on_local_applies_directly_no_routing` — impulse on local body applies directly, no routed ops
- [x] `inbound_event_applies_impulse_to_local_body` — inbound `ApplyImpulse` accelerates local body
- [x] `inbound_event_unknown_entity_is_silently_ignored` — inbound event for non-existent entity doesn't panic
- [x] `contact_between_local_and_proxy_flows_back` — collision between owned + proxy emits flow-back `ContactEvent`
- [x] `inbound_contact_event_suppresses_flowback_cycle` — inbound `ContactEvent` prevents re-emission of same pair
- [x] `create_joint_returns_none_when_proxy_involved` — joint creation with proxy returns `None`
- [x] `all_write_ops_route_for_proxy` — all 8 write ops route when target is proxy
- [x] `physics_event_json_roundtrip` — JSON serialize/deserialize roundtrip
- [x] `drain_routed_ops_is_empty_after_drain` — drain clears buffer
- [x] All 100 pre-existing tests still pass (110 total)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)