### PR TITLE
feat(startup): raise and assert fd limits at cluster startup (#109)

### DIFF
--- a/crates/arcane-infra/src/bin/arcane_cluster.rs
+++ b/crates/arcane-infra/src/bin/arcane_cluster.rs
@@ -20,6 +20,7 @@ use arcane_infra::cluster_runner::{self, ClusterEnv};
 fn main() -> Result<(), String> {
     #[cfg(feature = "cluster-ws")]
     {
+        arcane_infra::startup::raise_and_assert_fd_limit()?;
         let env = ClusterEnv::from_env()?;
         cluster_runner::run_cluster_loop(
             env.cluster_id,

--- a/crates/arcane-infra/src/bin/arcane_rapier_cluster.rs
+++ b/crates/arcane-infra/src/bin/arcane_rapier_cluster.rs
@@ -19,6 +19,7 @@ use arcane_infra::cluster_runner::{self, ClusterEnv};
 use arcane_infra::{RapierClusterSim, RapierConfig};
 
 fn main() -> Result<(), String> {
+    arcane_infra::startup::raise_and_assert_fd_limit()?;
     let env = ClusterEnv::from_env()?;
 
     let user_sim: Option<Arc<dyn ClusterSimulation>> = None;

--- a/crates/arcane-infra/src/lib.rs
+++ b/crates/arcane-infra/src/lib.rs
@@ -33,6 +33,8 @@ pub mod cluster_stats;
 #[cfg(feature = "cluster-ws")]
 pub mod physics_events_channel;
 #[cfg(feature = "cluster-ws")]
+pub mod startup;
+#[cfg(feature = "cluster-ws")]
 pub mod ws_server;
 
 #[cfg(feature = "rapier-cluster")]

--- a/crates/arcane-infra/src/spacetimedb_persist.rs
+++ b/crates/arcane-infra/src/spacetimedb_persist.rs
@@ -329,7 +329,11 @@ mod tests {
         let t0 = Instant::now();
         persist.maybe_persist(1, &[entry]);
         let elapsed = t0.elapsed().as_millis();
-        assert!(elapsed < 10, "maybe_persist blocked on full channel: {}ms", elapsed);
+        assert!(
+            elapsed < 10,
+            "maybe_persist blocked on full channel: {}ms",
+            elapsed
+        );
     }
 
     #[test]

--- a/crates/arcane-infra/src/spacetimedb_persist.rs
+++ b/crates/arcane-infra/src/spacetimedb_persist.rs
@@ -134,7 +134,7 @@ impl SpacetimeDbPersist {
 
             while let Ok(entries) = rx.recv() {
                 let count = persist_count_bg.fetch_add(1, Ordering::Relaxed);
-                let log_this_cycle = count % 10 == 0;
+                let log_this_cycle = count.is_multiple_of(10);
                 Self::persist_entries(&client, &url, &entries, max_batch_size, log_this_cycle);
             }
         });
@@ -306,7 +306,7 @@ mod tests {
         };
 
         let entry = mk_entry(Uuid::from_u128(100), 1.0, 2.0, 3.0);
-        persist.maybe_persist(0, &[entry.clone()]);
+        persist.maybe_persist(0, std::slice::from_ref(&entry));
 
         let received = rx.try_recv().unwrap();
         assert_eq!(received.len(), 1);
@@ -324,7 +324,7 @@ mod tests {
 
         let entry = mk_entry(Uuid::from_u128(101), 0.0, 0.0, 0.0);
         // Fill the channel
-        persist.maybe_persist(0, &[entry.clone()]);
+        persist.maybe_persist(0, std::slice::from_ref(&entry));
         // Second call should drop without blocking (channel full)
         let t0 = Instant::now();
         persist.maybe_persist(1, &[entry]);

--- a/crates/arcane-infra/src/startup.rs
+++ b/crates/arcane-infra/src/startup.rs
@@ -1,0 +1,97 @@
+use std::io;
+
+const DEFAULT_MIN_SOFT: u64 = 16_384;
+
+fn get_min_soft() -> u64 {
+    std::env::var("ARCANE_MIN_FD_LIMIT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MIN_SOFT)
+}
+
+fn getrlimit_nofile() -> io::Result<(u64, u64)> {
+    let mut rlim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let ret = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok((rlim.rlim_cur, rlim.rlim_max))
+}
+
+fn setrlimit_nofile(soft: u64, hard: u64) -> io::Result<()> {
+    let rlim = libc::rlimit {
+        rlim_cur: soft,
+        rlim_max: hard,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Raise the RLIMIT_NOFILE soft limit to the hard limit, then assert
+/// the result meets a minimum threshold.
+///
+/// Threshold is configurable via `ARCANE_MIN_FD_LIMIT` (default 16,384).
+///
+/// Call this at the top of every binary that accepts many sockets.
+pub fn raise_and_assert_fd_limit() -> Result<(), String> {
+    let min_soft = get_min_soft();
+
+    let (soft, hard) =
+        getrlimit_nofile().map_err(|e| format!("getrlimit(RLIMIT_NOFILE) failed: {e}"))?;
+
+    eprintln!("fd limits: soft={soft} hard={hard}");
+
+    if soft < hard {
+        if let Err(e) = setrlimit_nofile(hard, hard) {
+            eprintln!("setrlimit(RLIMIT_NOFILE, {hard}, {hard}) failed: {e} — continuing with soft={soft}");
+        } else {
+            eprintln!("fd limits: raised soft {soft} → {hard}");
+        }
+    }
+
+    let (final_soft, final_hard) =
+        getrlimit_nofile().map_err(|e| format!("getrlimit(RLIMIT_NOFILE) re-read failed: {e}"))?;
+
+    eprintln!("fd limits (final): soft={final_soft} hard={final_hard}");
+
+    if final_soft < min_soft {
+        return Err(format!(
+            "fd soft limit {final_soft} is below minimum {min_soft}. \
+             Fix: docker run --ulimit nofile={min_soft}:{min_soft} | \
+             systemd LimitNOFILE={min_soft} | \
+             /etc/security/limits.conf: * hard nofile {min_soft}"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn getrlimit_nofile_returns_sane_values() {
+        let (soft, hard) = getrlimit_nofile().unwrap();
+        assert!(soft > 0, "soft limit should be > 0, got {soft}");
+        assert!(hard >= soft, "hard {hard} should be >= soft {soft}");
+    }
+
+    #[test]
+    fn raise_and_assert_succeeds_in_test_env() {
+        // CI/test environments typically have high fd limits.
+        // This test verifies the function runs without panicking.
+        let result = raise_and_assert_fd_limit();
+        // May fail in very restricted containers — that's OK,
+        // the important thing is it doesn't panic.
+        if let Err(e) = &result {
+            eprintln!("raise_and_assert_fd_limit returned Err (expected in restricted envs): {e}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `startup::raise_and_assert_fd_limit()` — reads `RLIMIT_NOFILE`, raises soft to hard, exits with a clear actionable error if below minimum
- Wired into both `arcane-cluster` and `arcane-rapier-cluster` binaries as the first call in `main()`
- Minimum threshold configurable via `ARCANE_MIN_FD_LIMIT` env var (default 16,384)

## Decisions made

- **Used `libc` directly instead of the `nix` crate.** Considered: `nix::sys::resource::setrlimit`. Reason: `libc` is already a dependency (added in #146 for EMFILE detection). Two syscalls don't justify a new crate.
- **`Result<(), String>` return type.** Considered: custom error type. Reason: both binaries already use `Result<(), String>` for `main()`. No error recovery needed — if fd limits are too low, the binary should exit.
- **Default threshold 16,384.** Considered: scaling by expected player count. Reason: 16k is a safe universal default (covers 10k+ connections plus headroom for internal fds). Operators can override via env var for smaller deployments.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-features` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] Unit test: `getrlimit_nofile_returns_sane_values`
- [x] Unit test: `raise_and_assert_succeeds_in_test_env`

Closes #109