### PR TITLE
Epic E3 (AOI pipeline): activate L0 visibility filtering + path to private L1+ primitives (arcane#149)

### DIFF
--- a/crates/arcane-infra/src/node_core.rs
+++ b/crates/arcane-infra/src/node_core.rs
@@ -185,12 +185,35 @@ impl NodeCore {
             .unwrap_or(cfg.ws_port.saturating_add(1));
         crate::node_stats::serve_stats_http(stats_port, cfg.cluster_id.to_string(), stats.clone());
 
+        let visibility_filter: Option<Arc<dyn arcane_core::visibility::IVisibilityFilter>> =
+            std::env::var("ARCANE_AOI_RADIUS")
+                .ok()
+                .and_then(|s| s.parse::<f64>().ok())
+                .filter(|r| *r > 0.0)
+                .map(|r| {
+                    Arc::new(arcane_spatial::RadiusVisibilityFilter::new(r))
+                        as Arc<dyn arcane_core::visibility::IVisibilityFilter>
+                });
+        eprintln!(
+            "AOI: {}",
+            visibility_filter
+                .as_ref()
+                .map_or("off (full-mesh)".into(), |_| {
+                    std::env::var("ARCANE_AOI_RADIUS")
+                        .ok()
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .map(|r| format!("radius L0 ({})", r))
+                        .unwrap_or_default()
+                })
+        );
+
         crate::ws_server::run_ws_server(
             cfg.ws_port,
             state_rx,
             client_updates_tx,
             game_actions_tx,
             stats.clone(),
+            visibility_filter,
         );
 
         let (neighbor_tx, neighbor_rx) = std::sync::mpsc::channel();

--- a/crates/arcane-infra/src/node_core.rs
+++ b/crates/arcane-infra/src/node_core.rs
@@ -185,26 +185,18 @@ impl NodeCore {
             .unwrap_or(cfg.ws_port.saturating_add(1));
         crate::node_stats::serve_stats_http(stats_port, cfg.cluster_id.to_string(), stats.clone());
 
+        let aoi_radius: Option<f64> = std::env::var("ARCANE_AOI_RADIUS")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .filter(|r| *r > 0.0);
         let visibility_filter: Option<Arc<dyn arcane_core::visibility::IVisibilityFilter>> =
-            std::env::var("ARCANE_AOI_RADIUS")
-                .ok()
-                .and_then(|s| s.parse::<f64>().ok())
-                .filter(|r| *r > 0.0)
-                .map(|r| {
-                    Arc::new(arcane_spatial::RadiusVisibilityFilter::new(r))
-                        as Arc<dyn arcane_core::visibility::IVisibilityFilter>
-                });
+            aoi_radius.map(|r| {
+                Arc::new(arcane_spatial::RadiusVisibilityFilter::new(r))
+                    as Arc<dyn arcane_core::visibility::IVisibilityFilter>
+            });
         eprintln!(
             "AOI: {}",
-            visibility_filter
-                .as_ref()
-                .map_or("off (full-mesh)".into(), |_| {
-                    std::env::var("ARCANE_AOI_RADIUS")
-                        .ok()
-                        .and_then(|s| s.parse::<f64>().ok())
-                        .map(|r| format!("radius L0 ({})", r))
-                        .unwrap_or_default()
-                })
+            aoi_radius.map_or("off (full-mesh)".into(), |r| format!("radius L0 ({})", r))
         );
 
         crate::ws_server::run_ws_server(

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -407,6 +407,7 @@ pub fn run_ws_server(
     client_updates_tx: Sender<EntityStateEntry>,
     game_actions_tx: Sender<GameAction>,
     stats: Arc<NodeStats>,
+    visibility_filter: Option<Arc<dyn IVisibilityFilter>>,
 ) {
     // Bound the encoding rayon pool BEFORE spawning the tokio runtime,
     // so the pool is ready by the time the first tick fires.
@@ -429,6 +430,7 @@ pub fn run_ws_server(
             client_updates_tx,
             game_actions_tx,
             stats,
+            visibility_filter,
         ));
     });
 }
@@ -442,6 +444,7 @@ async fn ws_loop(
     client_updates_tx: Sender<EntityStateEntry>,
     game_actions_tx: Sender<GameAction>,
     stats: Arc<NodeStats>,
+    visibility_filter: Option<Arc<dyn IVisibilityFilter>>,
 ) {
     // Broadcast carries a TickBroadcast — per-entity FlatBuffer chunks plus
     // delta header and removed-id list, plus precomputed visibility masks.
@@ -491,8 +494,11 @@ async fn ws_loop(
 
                     let entity_count = tick.entity_metadata.len();
                     if ticks_until_recompute == 0 || entity_count != cached_entity_count {
-                        cached_masks =
-                            Arc::new(compute_visibility_masks(&tick, None, &positions_clone));
+                        cached_masks = Arc::new(compute_visibility_masks(
+                            &tick,
+                            visibility_filter.as_deref(),
+                            &positions_clone,
+                        ));
                         cached_entity_count = entity_count;
                         ticks_until_recompute = recompute_interval;
                     } else {
@@ -613,9 +619,9 @@ async fn ws_loop(
 #[cfg(test)]
 mod tests {
     use super::{
-        assemble_outbound_frame, encode_entity_chunk, entry_from_wire_player_state,
-        game_action_from_wire, pre_encode_tick, should_backoff_on_accept_error,
-        should_keep_ws_loop_running_on_broadcast_error,
+        assemble_outbound_frame, compute_visibility_masks, encode_entity_chunk,
+        entry_from_wire_player_state, game_action_from_wire, pre_encode_tick,
+        should_backoff_on_accept_error, should_keep_ws_loop_running_on_broadcast_error,
     };
     use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
     use arcane_core::visibility::IVisibilityFilter;
@@ -1199,6 +1205,59 @@ mod tests {
         let bytes_none_mask = assemble_outbound_frame(&pre_tick, None);
 
         assert_eq!(bytes_no_mask, bytes_none_mask);
+    }
+
+    /// Producer with filter: compute_visibility_masks with a filter should
+    /// generate per-subscriber masks that correctly filter entities by range.
+    #[test]
+    fn producer_with_filter_computes_masks_correctly() {
+        use dashmap::DashMap;
+
+        let entities = vec![
+            EntityStateEntry::new(
+                Uuid::from_u128(1),
+                Uuid::from_u128(99),
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+            EntityStateEntry::new(
+                Uuid::from_u128(2),
+                Uuid::from_u128(99),
+                Vec3::new(5.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+            EntityStateEntry::new(
+                Uuid::from_u128(3),
+                Uuid::from_u128(99),
+                Vec3::new(20.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        ];
+
+        let delta = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(99),
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: entities,
+            removed: Vec::new(),
+        };
+
+        let pre_tick = pre_encode_tick(&delta);
+
+        // Set up subscriber positions
+        let subscriber_positions = DashMap::new();
+        subscriber_positions.insert(1u64, Vec3::new(0.0, 0.0, 0.0)); // At origin
+        subscriber_positions.insert(2u64, Vec3::new(25.0, 0.0, 0.0)); // Far away
+
+        let filter = MockRadiusFilter::new(10.0);
+        let masks = compute_visibility_masks(&pre_tick, Some(&filter), &subscriber_positions);
+
+        // Subscriber 1 at (0, 0, 0) should see entities 1 and 2 (within radius 10)
+        assert_eq!(masks[&1u64], vec![true, true, false]);
+
+        // Subscriber 2 at (25, 0, 0) should only see entity 3 (entities 1 and 2 are > 10 away)
+        assert_eq!(masks[&2u64], vec![false, false, true]);
     }
 
     /// The pre-built `shared_full_frame` must be byte-identical to what

--- a/crates/arcane-infra/src/ws_server.rs
+++ b/crates/arcane-infra/src/ws_server.rs
@@ -626,9 +626,11 @@ mod tests {
     use arcane_core::replication_channel::{EntityStateDelta, EntityStateEntry};
     use arcane_core::visibility::IVisibilityFilter;
     use arcane_core::Vec3;
+    use arcane_spatial::RadiusVisibilityFilter;
     use arcane_wire::{
         ClientFrame, GameActionPayload, PlayerStatePayload, ServerFrame, Vec3 as WireVec3,
     };
+    use dashmap::DashMap;
     use tokio::sync::broadcast::error::RecvError;
     use uuid::Uuid;
 
@@ -1294,6 +1296,114 @@ mod tests {
             assembled,
             pre_tick.shared_full_frame.as_slice(),
             "shared_full_frame must be byte-identical to assemble_outbound_frame(tick, None)"
+        );
+    }
+
+    /// **E3.2 Correctness Test:** Deterministic multi-observer producer-level AOI test.
+    /// Verifies that each observer receives exactly its in-radius entities, both at the
+    /// visibility mask level and in the decoded wire frame. Uses the actual
+    /// `RadiusVisibilityFilter` from arcane-spatial, not a mock.
+    #[test]
+    fn aoi_multi_observer_deterministic_correctness() {
+        // Build a deterministic delta with known entity positions.
+        let entities = vec![
+            // Entity A at (0, 0, 0)
+            EntityStateEntry::new(
+                Uuid::from_u128(1),
+                Uuid::from_u128(99),
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+            // Entity B at (5, 0, 0) — within radius 10 of observer 1
+            EntityStateEntry::new(
+                Uuid::from_u128(2),
+                Uuid::from_u128(99),
+                Vec3::new(5.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+            // Entity C at (100, 0, 0) — far away
+            EntityStateEntry::new(
+                Uuid::from_u128(3),
+                Uuid::from_u128(99),
+                Vec3::new(100.0, 0.0, 0.0),
+                Vec3::new(0.0, 0.0, 0.0),
+            ),
+        ];
+
+        let delta = EntityStateDelta {
+            source_cluster_id: Uuid::from_u128(99),
+            seq: 1,
+            tick: 1,
+            timestamp: 0.0,
+            updated: entities,
+            removed: Vec::new(),
+        };
+
+        // Pre-encode the tick once; reuse across all observers.
+        let pre_tick = pre_encode_tick(&delta);
+        assert_eq!(pre_tick.entity_chunks.len(), 3);
+
+        // Set up two observers at different positions.
+        let subscriber_positions = DashMap::new();
+        subscriber_positions.insert(1u64, Vec3::new(0.0, 0.0, 0.0)); // Observer 1 at origin
+        subscriber_positions.insert(2u64, Vec3::new(100.0, 0.0, 0.0)); // Observer 2 far away
+
+        // Compute visibility masks using the actual RadiusVisibilityFilter.
+        let filter = RadiusVisibilityFilter::new(10.0);
+        let masks = compute_visibility_masks(&pre_tick, Some(&filter), &subscriber_positions);
+
+        // Verify masks at the visibility level.
+        // Observer 1 at (0,0,0): should see A (0,0,0) and B (5,0,0), not C (100,0,0).
+        assert_eq!(
+            masks[&1u64],
+            vec![true, true, false],
+            "Observer 1 should see entities A and B only"
+        );
+
+        // Observer 2 at (100,0,0): should see only C (100,0,0).
+        // A is 100 units away, B is ~95.5 units away — both outside radius 10.
+        assert_eq!(
+            masks[&2u64],
+            vec![false, false, true],
+            "Observer 2 should see entity C only"
+        );
+
+        // Verify decoded frames match expected entity subsets per observer.
+        // Observer 1 frame should include entities with IDs 1 and 2.
+        let bytes_obs1 = assemble_outbound_frame(&pre_tick, Some(&masks[&1u64]));
+        let decoded_obs1 =
+            arcane_wire::decode_server(&bytes_obs1).expect("Observer 1 frame decodes");
+        let ServerFrame::Delta(payload_obs1) = decoded_obs1;
+        assert_eq!(
+            payload_obs1.updated.len(),
+            2,
+            "Observer 1 should receive 2 entities"
+        );
+        assert_eq!(
+            payload_obs1.updated[0].entity_id,
+            Uuid::from_u128(1),
+            "Observer 1 first entity is A"
+        );
+        assert_eq!(
+            payload_obs1.updated[1].entity_id,
+            Uuid::from_u128(2),
+            "Observer 1 second entity is B"
+        );
+
+        // Observer 2 frame should include only entity with ID 3.
+        let bytes_obs2 = assemble_outbound_frame(&pre_tick, Some(&masks[&2u64]));
+        let decoded_obs2 =
+            arcane_wire::decode_server(&bytes_obs2).expect("Observer 2 frame decodes");
+        let ServerFrame::Delta(payload_obs2) = decoded_obs2;
+        assert_eq!(
+            payload_obs2.updated.len(),
+            1,
+            "Observer 2 should receive 1 entity"
+        );
+        assert_eq!(
+            payload_obs2.updated[0].entity_id,
+            Uuid::from_u128(3),
+            "Observer 2 entity is C"
         );
     }
 }


### PR DESCRIPTION
Living artifact for E3's pipeline work (Initiative arcane#173). Sub-PRs merge here; founder gate at epic→initiative.

**Re-scope reconciliation:** E3's original chunks (#150–#158: `IVisibilityFilter`, L0 `RadiusVisibilityFilter`, mask plumbing) are landed. The pump still computes masks with `None` (filtering inactive). The #161 'filter injection API' is stranded on the pre-E1 `epic/149-primitives` branch and needs re-doing against the post-E1 pump.

**This branch (off the post-E1 initiative tip):**
1. ✅ Activate L0 filtering in the pumped pipeline (PR #199, merged) — `ARCANE_AOI_RADIUS`, default off.
2a. ✅ **Automated AOI correctness test** (PR #201) — deterministic multi-observer producer test; no Redis/cluster/AWS; permanent CI regression guard.
2. Re-benchmark (full-mesh → per-observer ceiling lift) — ⏸️ AWS fleet, founder-authorized cost.
3. (Private, `arcane-primitives`) L1+ AOI primitives over the C-ABI (E2 pattern) as the proprietary upgrade.

Open base, progressive: L0 ships open + wired here; L1+ are the private upgrades.
